### PR TITLE
Remove nl2br extension to revert to standard Markdown line breaks

### DIFF
--- a/scripts/publish_post.py
+++ b/scripts/publish_post.py
@@ -115,7 +115,6 @@ def convert_markdown_to_html(md_content):
         'fenced_code',
         'tables',
         'toc',
-        'nl2br',
         'sane_lists',
     ])
     html = md.convert(md_content)


### PR DESCRIPTION
[convert_markdown_to_html()](vscode-file://vscode-app/c:/Users/pratticole/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) function, the script now uses standard Markdown line break rules:

Before: Single newlines (including CR/LF) in [.md](vscode-file://vscode-app/c:/Users/pratticole/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) files were converted to <br/> tags in HTML, creating hard line breaks.
After: Single newlines are ignored (treated as spaces), and only double newlines create paragraph breaks ([<p>](vscode-file://vscode-app/c:/Users/pratticole/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) tags) in HTML. This matches the original Markdown specification.