### PR TITLE
fix: use window.location.href for correct relative URL resolution

### DIFF
--- a/a/toc/toc-sidebar.js
+++ b/a/toc/toc-sidebar.js
@@ -1121,7 +1121,8 @@
         if (!post.dataset.originalHref) {
           post.dataset.originalHref = href;
         }
-        const url = new URL(href, window.location.origin);
+        // Use window.location.href as base to resolve relative paths correctly
+        const url = new URL(href, window.location.href);
         url.searchParams.set('highlight', query);
         post.setAttribute('href', url.pathname + url.search);
 


### PR DESCRIPTION
The search result links were giving 404 errors because new URL(href, origin) was resolving relative paths incorrectly. Using window.location.href as the base ensures the path /tbc/a/ is preserved.

Fixes #33