### PR TITLE
Fix: remove duplicate /BuildingCoder/ path segment in links

### DIFF
--- a/a/1027_revision.htm
+++ b/a/1027_revision.htm
@@ -239,7 +239,7 @@ Here a little wrapper class in C#:</p>
 
 <p>I added the updated version to <a href="https://github.com/jeremytammik/the_building_coder_samples">The Building Coder samples</a>.</p>
 
-<p>The new class lives beside the obsolete old one in the module <a href="https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/BuildingCoder/JtRevision.cs">JtRevision.cs</a>.</p>
+<p>The new class lives beside the obsolete old one in the module <a href="https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/JtRevision.cs">JtRevision.cs</a>.</p>
 
     </article>
     <div class="nav">

--- a/a/1081_set_view_background.htm
+++ b/a/1081_set_view_background.htm
@@ -124,7 +124,7 @@ which says "The settings shown in the Rendering Options Dialog are exposed..."</
 
 <p>The
 
-<a href="https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/BuildingCoder/CmdExportImage.cs">
+<a href="https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/CmdExportImage.cs">
 CmdExportImage</a> external
 
 command looks like a suitable place, used to

--- a/a/1202_plane_proj_pick.htm
+++ b/a/1202_plane_proj_pick.htm
@@ -472,9 +472,9 @@ repository.</p>
 
 <p>Here are direct links to the
 
-<a href="https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/BuildingCoder/Util.cs">Util</a> and
+<a href="https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/Util.cs">Util</a> and
 
-<a href="https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/BuildingCoder/CmdPickPoint3d.cs">CmdPickPoint3d</a> modules,
+<a href="https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/CmdPickPoint3d.cs">CmdPickPoint3d</a> modules,
 
 in case you prefer not to clone the whole thing.</p>
 

--- a/a/1246_webgl_sorted_level.htm
+++ b/a/1246_webgl_sorted_level.htm
@@ -190,7 +190,7 @@ FindElement and collector optimisation</a>.</p>
 <a href="https://github.com/jeremytammik/the_building_coder_samples">
 The Building Coder samples</a>, specifically the module
 
-<a href="https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/BuildingCoder/CmdCollectorPerformance.cs">
+<a href="https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/CmdCollectorPerformance.cs">
 CmdCollectorPerformance.cs</a>.</p>
 
 <!--

--- a/a/1282_face_point_tangent.htm
+++ b/a/1282_face_point_tangent.htm
@@ -333,7 +333,7 @@ element intersection and collision detection</span>.</p>
 
 <p>I added all the code described above to the new method PlaceFamilyInstanceOnFace in the module
 
-<a href="https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/BuildingCoder/CmdNewLightingFixture.cs">
+<a href="https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/CmdNewLightingFixture.cs">
 CmdNewLightingFixture.cs</a> in
 
 <a href="https://github.com/jeremytammik/the_building_coder_samples/releases/tag/2015.0.117.3">

--- a/a/1295_selection_changed_event.htm
+++ b/a/1295_selection_changed_event.htm
@@ -186,7 +186,7 @@ Secondly, this is an asynchronous method.</li>
 
 <p>Jeremy adds: I implemented a new external command
 
-<a href="https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/BuildingCoder/CmdSelectionChanged.cs">
+<a href="https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/CmdSelectionChanged.cs">
 CmdSelectionChanged</a> in
 
 <a href="https://github.com/jeremytammik/the_building_coder_samples">
@@ -302,7 +302,7 @@ The Building Coder samples</a> exercising this:</p>
 
 <p>The new external command method CmdSelectionChanged lives in the module
 
-<a href="https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/BuildingCoder/CmdSelectionChanged.cs">
+<a href="https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/CmdSelectionChanged.cs">
 CmdSelectionChanged.cs</a> in
 
 <a href="https://github.com/jeremytammik/the_building_coder_samples/releases/tag/2015.0.120.0">

--- a/a/1304_back_from_easter.htm
+++ b/a/1304_back_from_easter.htm
@@ -308,7 +308,7 @@ this exact issue.</p>
 
 <a href="https://github.com/jeremytammik/the_building_coder_samples">The Building Coder samples</a>
 
-<a href="https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/BuildingCoder/CmdCollectorPerformance.cs">
+<a href="https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/CmdCollectorPerformance.cs">
 CmdCollectorPerformance module</a>.</p>
 
 <p>Also, I am sure that you understand that the next developer's needs will differ ever so slightly from yours, so there cannot be a simple solution for this challenge.</p>

--- a/a/1314_transfer_wall_type.htm
+++ b/a/1314_transfer_wall_type.htm
@@ -67,7 +67,7 @@ Any update on API access for this tool?</p>
 <p>Therefore, it has been continually migrated every year, and the Revit 2015 version is provided in
 <a href="https://github.com/jeremytammik/the_building_coder_samples">The Building Coder samples GitHub repository</a>.</p>
 
-<p>The code for the <a href="https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/BuildingCoder/CmdCopyWallType.cs">external command CmdCopyWallType</a> is available there, already migrated to Revit 2015, and all the intervening versions as well.</p>
+<p>The code for the <a href="https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/CmdCopyWallType.cs">external command CmdCopyWallType</a> is available there, already migrated to Revit 2015, and all the intervening versions as well.</p>
 
 <p>As an added bonus, though, I went and tested the command for you.</p>
 

--- a/a/1323_au_line_intersect.htm
+++ b/a/1323_au_line_intersect.htm
@@ -180,7 +180,7 @@ I searched extensively for a solution with no results, so I decided to create my
 
 <p>I added it to
 <a href="https://github.com/jeremytammik/the_building_coder_samples">The Building Coder samples</a>
-<a href="https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/BuildingCoder/Util.cs">Util class</a> and
+<a href="https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/Util.cs">Util class</a> and
 simplified it a bit like this:</p>
 
 <pre class="code">

--- a/a/1361_rfa_api_iterate.html
+++ b/a/1361_rfa_api_iterate.html
@@ -153,7 +153,7 @@ for <a href="0832_find_element_optimise.htm">FindElement and collector optimisat
 <p>For future reference, I added this example code snippet
 to <a href="https://github.com/jeremytammik/the_building_coder_samples">The Building Coder samples</a>
 in the method <code>IterateOverCollector</code> in the
-module <a href="https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/BuildingCoder/CmdCollectorPerformance.cs">CmdCollectorPerformance.cs</a>,
+module <a href="https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/CmdCollectorPerformance.cs">CmdCollectorPerformance.cs</a>,
 currently at line 299.</p>
 <h4><a name="4"></a>Creating an Electrical Family</h4>
 <p><strong>Question:</strong>

--- a/a/1361_rfa_api_iterate.md
+++ b/a/1361_rfa_api_iterate.md
@@ -152,7 +152,7 @@ Then the snippet above can be cut down to something like this:
 For future reference, I added this example code snippet
 to [The Building Coder samples](https://github.com/jeremytammik/the_building_coder_samples)
 in the method `IterateOverCollector` in the
-module [CmdCollectorPerformance.cs](https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/BuildingCoder/CmdCollectorPerformance.cs),
+module [CmdCollectorPerformance.cs](https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/CmdCollectorPerformance.cs),
 currently at line 299.
 
 

--- a/a/1366_filter_rac_2016.html
+++ b/a/1366_filter_rac_2016.html
@@ -109,7 +109,7 @@ I am trying to write C# code to use the Revit API.</p>
 <p><strong>Answer:</strong>
 Have you looked at <a href="https://github.com/jeremytammik/the_building_coder_samples">The Building Coder</a> samples?</p>
 <p>Especially,
-the <a href="https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/BuildingCoder/CmdCollectorPerformance.cs">CmdCollectorPerformance module</a> provides
+the <a href="https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/CmdCollectorPerformance.cs">CmdCollectorPerformance module</a> provides
 a large number of such samples and probably covers all of the examples you list.</p>
 <p>Please let me know if anything is missing.</p>
 <p>Or, better still, fork the repository, add them yourself, and let me know so I can merge your update back in again.</p>

--- a/a/1366_filter_rac_2016.md
+++ b/a/1366_filter_rac_2016.md
@@ -91,7 +91,7 @@ But simply how to set/get could be nice...
 Have you looked at [The Building Coder](https://github.com/jeremytammik/the_building_coder_samples) samples?
 
 Especially,
-the [CmdCollectorPerformance module](https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/BuildingCoder/CmdCollectorPerformance.cs) provides
+the [CmdCollectorPerformance module](https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/CmdCollectorPerformance.cs) provides
 a large number of such samples and probably covers all of the examples you list.
 
 Please let me know if anything is missing.

--- a/a/1367_sheet_to_model_coord.html
+++ b/a/1367_sheet_to_model_coord.html
@@ -81,7 +81,7 @@ There is still a gap, as you will see if you read through Miro's sample below.</
 </blockquote>
 <p><strong>Jeremy says:</strong>
 I implemented a new external
-command <a href="https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/BuildingCoder/CmdSheetToModel.cs">CmdSheetToModel</a>
+command <a href="https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/CmdSheetToModel.cs">CmdSheetToModel</a>
 in <a href="https://github.com/jeremytammik/the_building_coder_samples">The Building Coder</a> samples
 version <a href="https://github.com/jeremytammik/the_building_coder_samples/releases/tag/2016.0.121.0">2016.0.121.0</a> to
 host and test Paolo's code.</p>
@@ -103,7 +103,7 @@ host and test Paolo's code.</p>
 <img src="img/sheet_to_model_04.png" alt="Sample model with linked DWFX" width="442"/>
 </center></p>
 <p>As said, I implemented a new external
-command <a href="https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/BuildingCoder/CmdSheetToModel.cs">CmdSheetToModel</a>
+command <a href="https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/CmdSheetToModel.cs">CmdSheetToModel</a>
 in <a href="https://github.com/jeremytammik/the_building_coder_samples">The Building Coder</a> samples
 version <a href="https://github.com/jeremytammik/the_building_coder_samples/releases/tag/2016.0.121.0">2016.0.121.0</a> to implement and test this.</p>
 <h4><a name="2"></a>Setting Plan View Location within Sheet</h4>
@@ -277,7 +277,7 @@ This is a known gap tracked as an enhancement request in the change request REVI
 
 <p>Thank you very much, Paolo and Miro, for sharing these important insights and samples!</p>
 <p>I just added Miro's sample code to
-the module <a href="https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/BuildingCoder/CmdSheetToModel.cs">CmdSheetToModel</a> as well,
+the module <a href="https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/CmdSheetToModel.cs">CmdSheetToModel</a> as well,
 in <a href="https://github.com/jeremytammik/the_building_coder_samples">The Building Coder</a> samples
 version <a href="https://github.com/jeremytammik/the_building_coder_samples/releases/tag/2016.0.121.1">2016.0.121.1</a>.</p>
     </article>

--- a/a/1367_sheet_to_model_coord.md
+++ b/a/1367_sheet_to_model_coord.md
@@ -66,7 +66,7 @@ Paolo Serra, Technical BIM Consultant at Autodesk in Milano, provides a nice exa
 
 **Jeremy says:**
 I implemented a new external
-command [CmdSheetToModel](https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/BuildingCoder/CmdSheetToModel.cs)
+command [CmdSheetToModel](https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/CmdSheetToModel.cs)
 in [The Building Coder](https://github.com/jeremytammik/the_building_coder_samples) samples
 version [2016.0.121.0](https://github.com/jeremytammik/the_building_coder_samples/releases/tag/2016.0.121.0) to
 host and test Paolo's code.
@@ -99,7 +99,7 @@ The generated test notes on each DWFX arc look like this:
 </center>
 
 As said, I implemented a new external
-command [CmdSheetToModel](https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/BuildingCoder/CmdSheetToModel.cs)
+command [CmdSheetToModel](https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/CmdSheetToModel.cs)
 in [The Building Coder](https://github.com/jeremytammik/the_building_coder_samples) samples
 version [2016.0.121.0](https://github.com/jeremytammik/the_building_coder_samples/releases/tag/2016.0.121.0) to implement and test this.
 
@@ -295,6 +295,6 @@ This is a known gap tracked as an enhancement request in the change request REVI
 Thank you very much, Paolo and Miro, for sharing these important insights and samples!
 
 I just added Miro's sample code to
-the module [CmdSheetToModel](https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/BuildingCoder/CmdSheetToModel.cs) as well,
+the module [CmdSheetToModel](https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/CmdSheetToModel.cs) as well,
 in [The Building Coder](https://github.com/jeremytammik/the_building_coder_samples) samples
 version [2016.0.121.1](https://github.com/jeremytammik/the_building_coder_samples/releases/tag/2016.0.121.1).

--- a/a/1375_flatten_to_directshape.html
+++ b/a/1375_flatten_to_directshape.html
@@ -87,7 +87,7 @@ I am still busy preparing my presentations for Autodesk University and making sl
 <p>This fits in well with the growing interest in direct shapes, as you can observe by the rapidly growing number of entries in
 the <span class="unavailable-link">DirectShape topic group</span>.</p>
 <p>I implemented a new external
-command <a href="https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/BuildingCoder/CmdFlatten.cs">CmdFlatten</a>
+command <a href="https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/CmdFlatten.cs">CmdFlatten</a>
 in <a href="https://github.com/jeremytammik/the_building_coder_samples">The Building Coder samples</a> to
 test and demonstrate this functionality.</p>
 <p>Nikolay's original code was for a future release of Revit, so some backwards adaptation was necessary.</p>
@@ -195,7 +195,7 @@ test and demonstrate this functionality.</p>
 </center></p>
 <p>If you wish to retain family instances, you should probably explore their geometry in a little bit more detail, e.g., to extract all the solids they contain and convert them individually.</p>
 <p>The current version is provided in the
-module <a href="https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/BuildingCoder/CmdFlatten.cs">CmdFlatten.cs</a>
+module <a href="https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/CmdFlatten.cs">CmdFlatten.cs</a>
 in <a href="https://github.com/jeremytammik/the_building_coder_samples">The Building Coder samples</a>
 <a href="https://github.com/jeremytammik/the_building_coder_samples/releases/tag/2016.0.123.0">release 2016.0.123.0</a>.</p>
 <p>Have fun playing with this, and many thanks to Nikolay for implementing and sharing it!</p>

--- a/a/1375_flatten_to_directshape.md
+++ b/a/1375_flatten_to_directshape.md
@@ -61,7 +61,7 @@ This fits in well with the growing interest in direct shapes, as you can observe
 the DirectShape topic group *(link unavailable)*.
 
 I implemented a new external
-command [CmdFlatten](https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/BuildingCoder/CmdFlatten.cs)
+command [CmdFlatten](https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/CmdFlatten.cs)
 in [The Building Coder samples](https://github.com/jeremytammik/the_building_coder_samples) to
 test and demonstrate this functionality.
 
@@ -182,7 +182,7 @@ The family instances get lost by the conversion in its current implementation:
 If you wish to retain family instances, you should probably explore their geometry in a little bit more detail, e.g., to extract all the solids they contain and convert them individually.
 
 The current version is provided in the
-module [CmdFlatten.cs](https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/BuildingCoder/CmdFlatten.cs)
+module [CmdFlatten.cs](https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/CmdFlatten.cs)
 in [The Building Coder samples](https://github.com/jeremytammik/the_building_coder_samples)
 [release 2016.0.123.0](https://github.com/jeremytammik/the_building_coder_samples/releases/tag/2016.0.123.0).
 

--- a/a/1382_filter_shortcuts.html
+++ b/a/1382_filter_shortcuts.html
@@ -126,7 +126,7 @@ I arrived back safe and sound in Switzerland after the exciting week at Autodesk
 the <a href="0333_collector_benchmark.htm">collector benchmark</a> in 2010.</p>
 <p>You can find more examples by searching the Internet for CmdCollectorPerformance, optionally adding 'revit api' or 'building coder'.</p>
 <p>They refer to
-the <a href="https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/BuildingCoder/CmdCollectorPerformance.cs">CmdCollectorPerformance.cs module</a>
+the <a href="https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/CmdCollectorPerformance.cs">CmdCollectorPerformance.cs module</a>
 in <a href="https://github.com/jeremytammik/the_building_coder_samples">The Building Coder samples</a>.</p>
 <p>Your question 2 regarding the optional use of <code>ToElements</code> is answered in my discussion of <a href="0872_toelementids_perf.htm">ToElementIds performance</a>.</p>
 <p>In short, you should avoid it unless you really need it.</p>
@@ -139,7 +139,7 @@ in which case <code>ToElementIds</code> can come in handy.</p>
 <p>If you say that you found LINQ to be incredibly fast, you will be happy to hear that the Revit filtered element collectors are at least twice as fast, in the worst case.</p>
 <p>For the sake of completeness, see <a href="#3">below</a> for more on the topic of the different Revit API filter types and quick versus slow ones.</p>
 <p>An interesting specialised topic is how to convert from .NET post-process filtering to built-in Revit filtering in order to optimise performance. One typical situation in which the .NET filtering may seem easier to implement is when checking for specific element parameter values.</p>
-<p>The collector performance samples pointed to above provide several samples of avoiding that by setting up appropriate element parameter filters instead, e.g., to <a href="https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/BuildingCoder/CmdCollectorPerformance.cs#L148-L200">filter for elements in a specific view having a specific phase</a>.</p>
+<p>The collector performance samples pointed to above provide several samples of avoiding that by setting up appropriate element parameter filters instead, e.g., to <a href="https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/CmdCollectorPerformance.cs#L148-L200">filter for elements in a specific view having a specific phase</a>.</p>
 <p>Please also explore and understand the related discussion
 on <a href="0832_find_element_optimise.htm">FindElement and collector
 optimisation</a>.</p>

--- a/a/1382_filter_shortcuts.md
+++ b/a/1382_filter_shortcuts.md
@@ -117,7 +117,7 @@ the [collector benchmark](0333_collector_benchmark.htm) in 2010.
 You can find more examples by searching the Internet for CmdCollectorPerformance, optionally adding 'revit api' or 'building coder'.
 
 They refer to
-the [CmdCollectorPerformance.cs module](https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/BuildingCoder/CmdCollectorPerformance.cs)
+the [CmdCollectorPerformance.cs module](https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/CmdCollectorPerformance.cs)
 in [The Building Coder samples](https://github.com/jeremytammik/the_building_coder_samples).
 
 Your question 2 regarding the optional use of `ToElements` is answered in my discussion of [ToElementIds performance](0872_toelementids_perf.htm).
@@ -140,7 +140,7 @@ For the sake of completeness, see [below](#3) for more on the topic of the diffe
 
 An interesting specialised topic is how to convert from .NET post-process filtering to built-in Revit filtering in order to optimise performance. One typical situation in which the .NET filtering may seem easier to implement is when checking for specific element parameter values.
 
-The collector performance samples pointed to above provide several samples of avoiding that by setting up appropriate element parameter filters instead, e.g., to [filter for elements in a specific view having a specific phase](https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/BuildingCoder/CmdCollectorPerformance.cs#L148-L200).
+The collector performance samples pointed to above provide several samples of avoiding that by setting up appropriate element parameter filters instead, e.g., to [filter for elements in a specific view having a specific phase](https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/CmdCollectorPerformance.cs#L148-L200).
 
 Please also explore and understand the related discussion
 on [FindElement and collector

--- a/a/1387_wall_openings.html
+++ b/a/1387_wall_openings.html
@@ -225,7 +225,7 @@ List<WallOpening2D> GetWallOpenings(
 in <a href="https://github.com/jeremytammik/the_building_coder_samples">The Building Coder samples</a>
 <a href="https://github.com/jeremytammik/the_building_coder_samples/releases/tag/2016.0.124.0">release 2016.0.124.0</a>.</p>
 <p>The external command name
-is <a href="https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/BuildingCoder/CmdWallOpenings.cs">CmdWallOpenings</a>.</p>
+is <a href="https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/CmdWallOpenings.cs">CmdWallOpenings</a>.</p>
 <p><strong>Response:</strong> Some corrections to my pseudocode:</p>
 <ul>
 <li>You are right about the view3D. I'm using the 2D view to get the elevation of the view range cut plane. For the ReferenceIntersector, I'm using the standard 3D view (just make sure it does not have an active section box and that all relevant elements are visible).</li>
@@ -316,7 +316,7 @@ Note the username suffix and the lowercase "d".</p>
 <p>Define a parameter specifying the minimum opening size, and then fan a comb up the entire wall side.</p>
 <p>Retrieve all the resulting intersection points, sort them by proximity, eliminate duplicates, and Bob's your uncle.</p>
 <h4><a name="3"></a>CmdWallOpenings Implementation</h4>
-<p>As said, I implemented and tested this algorithm in a new <a href="https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/BuildingCoder/CmdWallOpenings.cs">external command CmdWallOpenings</a>
+<p>As said, I implemented and tested this algorithm in a new <a href="https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/CmdWallOpenings.cs">external command CmdWallOpenings</a>
 in <a href="https://github.com/jeremytammik/the_building_coder_samples">The Building Coder samples</a>
 <a href="https://github.com/jeremytammik/the_building_coder_samples/releases/tag/2016.0.124.0">release 2016.0.124.0</a>.</p>
 <p>I only performed minimal testing of it on these three different walls:</p>

--- a/a/1387_wall_openings.md
+++ b/a/1387_wall_openings.md
@@ -230,7 +230,7 @@ in [The Building Coder samples](https://github.com/jeremytammik/the_building_cod
 [release 2016.0.124.0](https://github.com/jeremytammik/the_building_coder_samples/releases/tag/2016.0.124.0).
 
 The external command name
-is [CmdWallOpenings](https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/BuildingCoder/CmdWallOpenings.cs).
+is [CmdWallOpenings](https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/CmdWallOpenings.cs).
 
 
 **Response:** Some corrections to my pseudocode:
@@ -335,7 +335,7 @@ Retrieve all the resulting intersection points, sort them by proximity, eliminat
 
 #### <a name="3"></a>CmdWallOpenings Implementation
 
-As said, I implemented and tested this algorithm in a new [external command CmdWallOpenings](https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/BuildingCoder/CmdWallOpenings.cs)
+As said, I implemented and tested this algorithm in a new [external command CmdWallOpenings](https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/CmdWallOpenings.cs)
 in [The Building Coder samples](https://github.com/jeremytammik/the_building_coder_samples).
 
 I cleaned it up a bit more, and the version presented below is

--- a/a/1388_project_param_guid.html
+++ b/a/1388_project_param_guid.html
@@ -578,7 +578,7 @@ on <a href="http://forums.autodesk.com/t5/revit-api/create-project-parameter-wit
 <h4><a name="4"></a>Download</h4>
 <p>I integrated CoderBoy's code
 into <a href="https://github.com/jeremytammik/the_building_coder_samples">The Building Coder samples</a>
-<a href="https://github.com/jeremytammik/the_building_coder_samples/releases/tag/2016.0.125.2">release 2016.0.125.2</a>, in the module <a href="https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/BuildingCoder/CmdProjectParameterGuids.cs">CmdProjectParameterGuids</a>.</p>
+<a href="https://github.com/jeremytammik/the_building_coder_samples/releases/tag/2016.0.125.2">release 2016.0.125.2</a>, in the module <a href="https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/CmdProjectParameterGuids.cs">CmdProjectParameterGuids</a>.</p>
 <h4><a name="5"></a>Discussion</h4>
 <p>Here is a summary of the discussion leading up to this.</p>
 <p>It provides some interesting insight into all the work, research and collaboration required for this implementation.</p>

--- a/a/1388_project_param_guid.md
+++ b/a/1388_project_param_guid.md
@@ -566,7 +566,7 @@ It provides an interesting and important read, with quite extensive documentatio
 
 I integrated CoderBoy's code
 into [The Building Coder samples](https://github.com/jeremytammik/the_building_coder_samples)
-[release 2016.0.125.2](https://github.com/jeremytammik/the_building_coder_samples/releases/tag/2016.0.125.2), in the module [CmdProjectParameterGuids](https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/BuildingCoder/CmdProjectParameterGuids.cs).
+[release 2016.0.125.2](https://github.com/jeremytammik/the_building_coder_samples/releases/tag/2016.0.125.2), in the module [CmdProjectParameterGuids](https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/CmdProjectParameterGuids.cs).
 
 
 #### <a name="5"></a>Discussion

--- a/a/1389_wall_opening_profiles.html
+++ b/a/1389_wall_opening_profiles.html
@@ -95,7 +95,7 @@ I continue my rather active involvement in the Revit API discussion forum. Lets 
 </blockquote>
 <h4><a name="4"></a>CmdGetWallOpeningProfiles</h4>
 <p>Seeing as I already implemented a command for the ray tracing approach, I went ahead and added this alternative of Scott's as well as another external
-command <a href="https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/BuildingCoder/CmdWallOpeningProfiles.cs">CmdWallOpeningProfiles</a> to
+command <a href="https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/CmdWallOpeningProfiles.cs">CmdWallOpeningProfiles</a> to
 <a href="https://github.com/jeremytammik/the_building_coder_samples">The Building Coder samples</a>.</p>
 <p>I tested both Scott's original Revit 2015 implementation and its new incarnation in Revit 2016.</p>
 <p>Scott's implementation includes several noteworthy little details, e.g.:</p>
@@ -324,7 +324,7 @@ command <a href="https://github.com/jeremytammik/the_building_coder_samples/blob
 <img src="img/wall_openings_10.png" alt="Wall openings" width="514">
 </center></p>
 <p>As said, this code is provided by the external
-command <a href="https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/BuildingCoder/CmdWallOpeningProfiles.cs">CmdWallOpeningProfiles</a> in
+command <a href="https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/CmdWallOpeningProfiles.cs">CmdWallOpeningProfiles</a> in
 <a href="https://github.com/jeremytammik/the_building_coder_samples">The Building Coder samples</a>,
 and the version presented above is
 <a href="https://github.com/jeremytammik/the_building_coder_samples/releases/tag/2016.0.126.1">release 2016.0.126.1</a>.</p>

--- a/a/1389_wall_opening_profiles.md
+++ b/a/1389_wall_opening_profiles.md
@@ -88,7 +88,7 @@ That is a false assumption, as proven by the later answer by Scott Wilson, who v
 #### <a name="4"></a>CmdGetWallOpeningProfiles
 
 Seeing as I already implemented a command for the ray tracing approach, I went ahead and added this alternative of Scott's as well as another external
-command [CmdWallOpeningProfiles](https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/BuildingCoder/CmdWallOpeningProfiles.cs) to
+command [CmdWallOpeningProfiles](https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/CmdWallOpeningProfiles.cs) to
 [The Building Coder samples](https://github.com/jeremytammik/the_building_coder_samples).
 
 I tested both Scott's original Revit 2015 implementation and its new incarnation in Revit 2016.
@@ -331,7 +331,7 @@ The command executes, generates the model lines representing the opening face ed
 </center>
 
 As said, this code is provided by the external
-command [CmdWallOpeningProfiles](https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/BuildingCoder/CmdWallOpeningProfiles.cs) in
+command [CmdWallOpeningProfiles](https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/CmdWallOpeningProfiles.cs) in
 [The Building Coder samples](https://github.com/jeremytammik/the_building_coder_samples),
 and the version presented above is
 [release 2016.0.126.1](https://github.com/jeremytammik/the_building_coder_samples/releases/tag/2016.0.126.1).

--- a/a/1406_mep_element_shape_4.html
+++ b/a/1406_mep_element_shape_4.html
@@ -154,7 +154,7 @@ in <a href="http://adndevblog.typepad.com/aec/2013/03/how-to-get-the-duct-sectio
 <p>I added this code
 to <a href="https://github.com/jeremytammik/the_building_coder_samples">The Building Coder samples</a>
 <a href="https://github.com/jeremytammik/the_building_coder_samples/releases/tag/2016.0.126.3">release 2016.0.126.3</a>,
-in the module <a href="https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/BuildingCoder/CmdMepElementShape.cs#L721-L745">CmdMepElementShape.cs, in lines 721-745</a>.</p>
+in the module <a href="https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/CmdMepElementShape.cs#L721-L745">CmdMepElementShape.cs, in lines 721-745</a>.</p>
 <p>Here is the result of a test run on the first two elements in this sequence of rectangular ducts and transitions:</p>
 <p><center>
 <img src="img/duct_shape_2016_01.png" alt="Two ducts and a transition" width="503">

--- a/a/1406_mep_element_shape_4.md
+++ b/a/1406_mep_element_shape_4.md
@@ -156,7 +156,7 @@ In your case, that might look like this:
 I added this code
 to [The Building Coder samples](https://github.com/jeremytammik/the_building_coder_samples)
 [release 2016.0.126.3](https://github.com/jeremytammik/the_building_coder_samples/releases/tag/2016.0.126.3),
-in the module [CmdMepElementShape.cs, in lines 721-745](https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/BuildingCoder/CmdMepElementShape.cs#L721-L745).
+in the module [CmdMepElementShape.cs, in lines 721-745](https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/CmdMepElementShape.cs#L721-L745).
 
 Here is the result of a test run on the first two elements in this sequence of rectangular ducts and transitions:
 

--- a/a/1410_delete_print_setup.html
+++ b/a/1410_delete_print_setup.html
@@ -137,9 +137,9 @@ Is it necessary to create a plane for such a curve?</p>
 <li><a href="0999_midcurve.htm">Generating a MidCurve Between Two Curve Elements</a></li>
 </ul>
 <p>A <code>Creator</code> model curve helper class is also included in <a href="https://github.com/jeremytammik/the_building_coder_samples">The Building Coder samples</a>,
-in the module <a href="https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/BuildingCoder/Creator.cs">Creator.cs</a>.</p>
+in the module <a href="https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/Creator.cs">Creator.cs</a>.</p>
 <p>Furthermore, the <code>CmdDetailCurves</code> sample command shows how to create detail lines, in the
-module <a href="https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/BuildingCoder/CmdDetailCurves.cs">CmdDetailCurves.cs</a>.</p>
+module <a href="https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/CmdDetailCurves.cs">CmdDetailCurves.cs</a>.</p>
 <p>The GitHub repository master branch is always up to date, and previous versions of the Revit API are supported by
 different <a href="https://github.com/jeremytammik/the_building_coder_samples/releases">releases</a>.</p>
 <p>As you should probably know if you are reading this, detail lines can only be created and viewed in a plan view.</p>

--- a/a/1410_delete_print_setup.md
+++ b/a/1410_delete_print_setup.md
@@ -125,10 +125,10 @@ The Building Coder provides a number of samples, e.g.:
 - [Generating a MidCurve Between Two Curve Elements](0999_midcurve.htm)
 
 A `Creator` model curve helper class is also included in [The Building Coder samples](https://github.com/jeremytammik/the_building_coder_samples),
-in the module [Creator.cs](https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/BuildingCoder/Creator.cs).
+in the module [Creator.cs](https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/Creator.cs).
 
 Furthermore, the `CmdDetailCurves` sample command shows how to create detail lines, in the
-module [CmdDetailCurves.cs](https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/BuildingCoder/CmdDetailCurves.cs).
+module [CmdDetailCurves.cs](https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/CmdDetailCurves.cs).
 
 The GitHub repository master branch is always up to date, and previous versions of the Revit API are supported by
 different [releases](https://github.com/jeremytammik/the_building_coder_samples/releases).

--- a/a/1417_distinguish_rooms.html
+++ b/a/1417_distinguish_rooms.html
@@ -159,7 +159,7 @@ A couple of interesting Revit API issues were resolved during my recent absence.
 <p>Jeremy adds: I added Miro's test methods as <code>DistinguishRoomsDraft</code> and <code>DistinguishRoom</code>
 to <a href="https://github.com/jeremytammik/the_building_coder_samples">The Building Coder samples</a>
 <a href="https://github.com/jeremytammik/the_building_coder_samples/releases/tag/2016.0.126.8">release 2016.0.126.8</a> in
-the module <a href="https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/BuildingCoder/CmdListAllRooms.cs#L30-L110">CmdListAllRooms.cs</a>.</p>
+the module <a href="https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/CmdListAllRooms.cs#L30-L110">CmdListAllRooms.cs</a>.</p>
 <p>Many thanks to Miro and Diane for the interesting question, research and answer.</p>
 <p>I actually cleaned up both the draft and final methods before publishing them, with the two following strong recommendations
 on <a href="#2">performance</a> and <a href="#3">exception handling</a>:</p>

--- a/a/1417_distinguish_rooms.md
+++ b/a/1417_distinguish_rooms.md
@@ -144,7 +144,7 @@ Here is the final solution implementing your suggestion:
 Jeremy adds: I added Miro's test methods as `DistinguishRoomsDraft` and `DistinguishRoom`
 to [The Building Coder samples](https://github.com/jeremytammik/the_building_coder_samples)
 [release 2016.0.126.8](https://github.com/jeremytammik/the_building_coder_samples/releases/tag/2016.0.126.8) in
-the module [CmdListAllRooms.cs](https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/BuildingCoder/CmdListAllRooms.cs#L30-L110).
+the module [CmdListAllRooms.cs](https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/CmdListAllRooms.cs#L30-L110).
 
 Many thanks to Miro and Diane for the interesting question, research and answer.
 

--- a/a/1429_stable_references.html
+++ b/a/1429_stable_references.html
@@ -358,7 +358,7 @@ the <a href="http://forums.autodesk.com/t5/revit-api/geometry-returns-no-referen
 <p>P.S. I added Scott's sample code
 to <a href="https://github.com/jeremytammik/the_building_coder_samples">The Building Coder samples</a>
 <a href="https://github.com/jeremytammik/the_building_coder_samples/releases/tag/2016.0.127.3">release 2016.0.127.3</a> in the
-module <a href="https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/BuildingCoder/CmdDimensionInstanceOrigin.cs#L27-L251">CmdDimensionInstanceOrigin.cs</a>.</p>
+module <a href="https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/CmdDimensionInstanceOrigin.cs#L27-L251">CmdDimensionInstanceOrigin.cs</a>.</p>
 <h4><a name="5"></a>Importance of Setting the Detail Level</h4>
 <p>An addendum by Pat Hague to Scott's original post:</p>
 <p>I would like to stress the importance of setting</p>

--- a/a/1429_stable_references.md
+++ b/a/1429_stable_references.md
@@ -363,7 +363,7 @@ Many thanks to Scott for all his research, creating, sharing, documenting this, 
 P.S. I added Scott's sample code
 to [The Building Coder samples](https://github.com/jeremytammik/the_building_coder_samples)
 [release 2016.0.127.3](https://github.com/jeremytammik/the_building_coder_samples/releases/tag/2016.0.127.3) in the
-module [CmdDimensionInstanceOrigin.cs](https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/BuildingCoder/CmdDimensionInstanceOrigin.cs#L27-L251).
+module [CmdDimensionInstanceOrigin.cs](https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/CmdDimensionInstanceOrigin.cs#L27-L251).
 
 #### <a name="5"></a>Importance of Setting the Detail Level
 

--- a/a/1446_point_bc_2017_sdk.html
+++ b/a/1446_point_bc_2017_sdk.html
@@ -198,7 +198,7 @@ and <a href="http://www.3dwebfest.com">3D Web Fest</a>.</p>
 to <a href="https://github.com/jeremytammik/the_building_coder_samples">The Building Coder Samples</a> 
 <a href="https://github.com/jeremytammik/the_building_coder_samples/releases/tag/2017.0.127.5">release 2017.0.127.5</a>
 in the module 
-<a href="https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/BuildingCoder/CmdNewLineLoad.cs#L30-L77">CmdNewLineLoad.cs</a>.</p>
+<a href="https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/CmdNewLineLoad.cs#L30-L77">CmdNewLineLoad.cs</a>.</p>
     </article>
     <div class="nav">
         <a href="index.html">← Back to Index</a>

--- a/a/1446_point_bc_2017_sdk.md
+++ b/a/1446_point_bc_2017_sdk.md
@@ -184,4 +184,4 @@ I added it
 to [The Building Coder Samples](https://github.com/jeremytammik/the_building_coder_samples) 
 [release 2017.0.127.5](https://github.com/jeremytammik/the_building_coder_samples/releases/tag/2017.0.127.5)
 in the module 
-[CmdNewLineLoad.cs](https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/BuildingCoder/CmdNewLineLoad.cs#L30-L77).
+[CmdNewLineLoad.cs](https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/CmdNewLineLoad.cs#L30-L77).

--- a/a/1456_bounding_section_box.html
+++ b/a/1456_bounding_section_box.html
@@ -166,8 +166,8 @@ address questions related to determining a bounding box for selected elements or
 
 <p>Check it out live 
 in <a href="https://github.com/jeremytammik/the_building_coder_samples">The Building Coder samples</a>
-<a href="https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/BuildingCoder/Util.cs">Util.cs utility class</a>, currently
-in <a href="https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/BuildingCoder/Util.cs#L1275-L1305">lines 1275-1305</a>.</p>
+<a href="https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/Util.cs">Util.cs utility class</a>, currently
+in <a href="https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/Util.cs#L1275-L1305">lines 1275-1305</a>.</p>
 <p>Here follow some usage examples.</p>
 <h4><a name="7"></a>Bounding Box and Lower Left Corner of Rooms</h4>
 <p>Question on <a href="http://forums.autodesk.com/t5/revit-api/how-to-generate-x-and-y-axes-of-rooms-in-the-revit-api-in/m-p/6452079">how to generate x and y-axes of rooms in the Revit API in millimetres</a>:</p>
@@ -197,7 +197,7 @@ in <a href="https://github.com/jeremytammik/the_building_coder_samples/blob/mast
 <p>Third, you might also be able to use the room bounding box. That would be simpler still, but maybe less precise.</p>
 <p>I implemented the second option for you
 in <a href="https://github.com/jeremytammik/the_building_coder_samples">The Building Coder samples</a>, in the
-module <a href="https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/BuildingCoder/CmdListAllRooms.cs">CmdListAllRooms.cs</a>.</p>
+module <a href="https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/CmdListAllRooms.cs">CmdListAllRooms.cs</a>.</p>
 <p>In it, I iterate over all the room boundary segments, tessellate them, and use the resulting points to generate an accurate 2D bounding box for the room:</p>
 <pre class="code">
 &nbsp;&nbsp;<span style="color:gray;">///</span><span style="color:green;">&nbsp;</span><span style="color:gray;">&lt;</span><span style="color:gray;">summary</span><span style="color:gray;">&gt;</span>

--- a/a/1456_bounding_section_box.md
+++ b/a/1456_bounding_section_box.md
@@ -160,8 +160,8 @@ In order to help address these, I started off by implementing two `ExpandToConta
 
 Check it out live 
 in [The Building Coder samples](https://github.com/jeremytammik/the_building_coder_samples)
-[Util.cs utility class](https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/BuildingCoder/Util.cs), currently
-in [lines 1275-1305](https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/BuildingCoder/Util.cs#L1275-L1305).
+[Util.cs utility class](https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/Util.cs), currently
+in [lines 1275-1305](https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/Util.cs#L1275-L1305).
 
 Here follow some usage examples.
 
@@ -212,7 +212,7 @@ Third, you might also be able to use the room bounding box. That would be simple
 
 I implemented the second option for you
 in [The Building Coder samples](https://github.com/jeremytammik/the_building_coder_samples), in the
-module [CmdListAllRooms.cs](https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/BuildingCoder/CmdListAllRooms.cs).
+module [CmdListAllRooms.cs](https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/CmdListAllRooms.cs).
 
 In it, I iterate over all the room boundary segments, tessellate them, and use the resulting points to generate an accurate 2D bounding box for the room:
  

--- a/a/1469_macromanager.html
+++ b/a/1469_macromanager.html
@@ -102,7 +102,7 @@ search for <strong>MacroManager API</strong>.</p>
 </center></p>
 <p><strong>Jeremy says:</strong> Look
 at <a href="https://github.com/jeremytammik/the_building_coder_samples">The Building Coder samples</a>
-new <a href="https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/BuildingCoder/CmdDeleteMacros.cs">CmdDeleteMacros.cs module</a>
+new <a href="https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/CmdDeleteMacros.cs">CmdDeleteMacros.cs module</a>
 in <a href="https://github.com/jeremytammik/the_building_coder_samples/releases/tag/2017.0.129.0">release 2017.0.129.0</a>.</p>
 <p>Just as Revitalizer suggests, I was forced to add references to <code>RevitAPIMacros.dll</code> and <code>RevitAPIUIMacros.dll</code> in The Building Coder samples Visual Studio project specifically for this command.</p>
 <pre class="code">

--- a/a/1469_macromanager.md
+++ b/a/1469_macromanager.md
@@ -90,7 +90,7 @@ Actually, a reference to `RevitAPIMacrosInterop.dll` solved the problem at last 
 
 **Jeremy says:** Look
 at [The Building Coder samples](https://github.com/jeremytammik/the_building_coder_samples)
-new [CmdDeleteMacros.cs module](https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/BuildingCoder/CmdDeleteMacros.cs)
+new [CmdDeleteMacros.cs module](https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/CmdDeleteMacros.cs)
 in [release 2017.0.129.0](https://github.com/jeremytammik/the_building_coder_samples/releases/tag/2017.0.129.0).
 
 Just as Revitalizer suggests, I was forced to add references to `RevitAPIMacros.dll` and `RevitAPIUIMacros.dll` in The Building Coder samples Visual Studio project specifically for this command.

--- a/a/1476_roomedit3d_forge_warn.html
+++ b/a/1476_roomedit3d_forge_warn.html
@@ -123,7 +123,7 @@ fine for me.</p>
 <p>I added it
 to <a href="https://github.com/jeremytammik/the_building_coder_samples">The Building Coder samples</a>
 <a href="https://github.com/jeremytammik/the_building_coder_samples/releases/tag/2017.0.130.1">release 2017.0.130.1</a> in
-the module <a href="https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/BuildingCoder/CmdPreprocessFailure.cs#L44-L67">CmdPreprocessFailure.cs</a>.</p>
+the module <a href="https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/CmdPreprocessFailure.cs#L44-L67">CmdPreprocessFailure.cs</a>.</p>
 <h4><a name="3"></a>Roomedit3dv3 Transform Viewer Extension</h4>
 <p>I am implementing
 the <a href="https://github.com/Autodesk-Forge/forge-boilers.nodejs/tree/roomedit3d">roomedit3dv3</a> sample

--- a/a/1476_roomedit3d_forge_warn.md
+++ b/a/1476_roomedit3d_forge_warn.md
@@ -107,7 +107,7 @@ Many thanks to Adam and Wolfgang for sharing this solution!
 I added it
 to [The Building Coder samples](https://github.com/jeremytammik/the_building_coder_samples)
 [release 2017.0.130.1](https://github.com/jeremytammik/the_building_coder_samples/releases/tag/2017.0.130.1) in
-the module [CmdPreprocessFailure.cs](https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/BuildingCoder/CmdPreprocessFailure.cs#L44-L67).
+the module [CmdPreprocessFailure.cs](https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/CmdPreprocessFailure.cs#L44-L67).
 
 
 #### <a name="3"></a>Roomedit3dv3 Transform Viewer Extension

--- a/a/1477_solid_bbox_forge.html
+++ b/a/1477_solid_bbox_forge.html
@@ -151,7 +151,7 @@ a <span class="unavailable-link">DirectShape element</span>.</p>
 <p>I added <code>CreateSolidFromBoundingBox</code> as a new utility method 
 to <a href="https://github.com/jeremytammik/the_building_coder_samples">The Building Coder samples</a>
 <a href="https://github.com/jeremytammik/the_building_coder_samples/releases/tag/2017.0.130.2">release 2017.0.130.2</a> in
-the module <a href="https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/BuildingCoder/Util.cs#L404-L453">Util.cs</a>,
+the module <a href="https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/Util.cs#L404-L453">Util.cs</a>,
 with <a href="https://github.com/jeremytammik/the_building_coder_samples/compare/2017.0.130.1...2017.0.130.2">these diffs to the previous release</a>.</p>
 <h4><a name="3"></a>Forge Webinar Series 4 &ndash; Viewer</h4>
 <p><a href="http://adndevblog.typepad.com/aec/jaime-rosales.html">Jaime Rosales</a>

--- a/a/1477_solid_bbox_forge.md
+++ b/a/1477_solid_bbox_forge.md
@@ -149,7 +149,7 @@ Many thanks to Owen for sharing this solution and putting together such a nice r
 I added `CreateSolidFromBoundingBox` as a new utility method 
 to [The Building Coder samples](https://github.com/jeremytammik/the_building_coder_samples)
 [release 2017.0.130.2](https://github.com/jeremytammik/the_building_coder_samples/releases/tag/2017.0.130.2) in
-the module [Util.cs](https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/BuildingCoder/Util.cs#L404-L453),
+the module [Util.cs](https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/Util.cs#L404-L453),
 with [these diffs to the previous release](https://github.com/jeremytammik/the_building_coder_samples/compare/2017.0.130.1...2017.0.130.2).
 
 

--- a/a/1482_material_asset_texture.html
+++ b/a/1482_material_asset_texture.html
@@ -147,7 +147,7 @@ resolved by the development team:</p>
 <p>I hope this helps.</p>
 <p>I extracted the development team code from their macro and added it
 to <a href="https://github.com/jeremytammik/the_building_coder_samples">The Building Coder samples</a>
-module <a href="https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/BuildingCoder/CmdGetMaterials.cs#L64-L652">CmdGetMaterials.cs</a>
+module <a href="https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/CmdGetMaterials.cs#L64-L652">CmdGetMaterials.cs</a>
 in <a href="https://github.com/jeremytammik/the_building_coder_samples/releases/tag/2017.0.130.4">release 2017.0.130.4</a>, cf.
 the <a href="https://github.com/jeremytammik/the_building_coder_samples/compare/2017.0.130.3...2017.0.130.4">diff</a>.</p>
 <p>By the way, this code pulls in two new namespaces that were not previously used:</p>

--- a/a/1482_material_asset_texture.md
+++ b/a/1482_material_asset_texture.md
@@ -145,7 +145,7 @@ I hope this helps.
 
 I extracted the development team code from their macro and added it
 to [The Building Coder samples](https://github.com/jeremytammik/the_building_coder_samples)
-module [CmdGetMaterials.cs](https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/BuildingCoder/CmdGetMaterials.cs#L64-L652)
+module [CmdGetMaterials.cs](https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/CmdGetMaterials.cs#L64-L652)
 in [release 2017.0.130.4](https://github.com/jeremytammik/the_building_coder_samples/releases/tag/2017.0.130.4), cf.
 the [diff](https://github.com/jeremytammik/the_building_coder_samples/compare/2017.0.130.3...2017.0.130.4).
 

--- a/a/1490_create_line_style.html
+++ b/a/1490_create_line_style.html
@@ -187,7 +187,7 @@ Here is a macro that creates and sets up a new Line Style:</p>
 <p>I added Scott's code 
 to <a href="https://github.com/jeremytammik/the_building_coder_samples">The Building Coder samples</a> 
 <a href="https://github.com/jeremytammik/the_building_coder_samples/releases/tag/2017.0.130.4">release 2017.0.131.0</a> 
-in the new module <a href="https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/BuildingCoder/CmdCreateLineStyle.cs">CmdCreateLineStyle.cs</a>.</p>
+in the new module <a href="https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/CmdCreateLineStyle.cs">CmdCreateLineStyle.cs</a>.</p>
 <p>Thank you very much, Scott, for pointing out and demonstrating this important enhancement!</p>
     </article>
     <div class="nav">

--- a/a/1490_create_line_style.md
+++ b/a/1490_create_line_style.md
@@ -194,6 +194,6 @@ Here is a macro that creates and sets up a new Line Style:
 I added Scott's code 
 to [The Building Coder samples](https://github.com/jeremytammik/the_building_coder_samples) 
 [release 2017.0.131.0](https://github.com/jeremytammik/the_building_coder_samples/releases/tag/2017.0.130.4) 
-in the new module [CmdCreateLineStyle.cs](https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/BuildingCoder/CmdCreateLineStyle.cs).
+in the new module [CmdCreateLineStyle.cs](https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/CmdCreateLineStyle.cs).
 
 Thank you very much, Scott, for pointing out and demonstrating this important enhancement!

--- a/a/1493_au_2017_1_sdk_freeze.html
+++ b/a/1493_au_2017_1_sdk_freeze.html
@@ -262,7 +262,7 @@ Leo van Ruijven thought leader - http://www.iso.org/iso/catalogue_detail.htm?csn
 <p>Thanks to Jim for sharing these snippets!</p>
 <p>I also added them 
 to <a href="https://github.com/jeremytammik/the_building_coder_samples">The Building Coder samples</a>
-<a href="https://github.com/jeremytammik/the_building_coder_samples/releases/tag/2017.0.131.1">release 2017.0.131.1</a> in the module  <a href="https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/BuildingCoder/CmdColumnRound.cs#L30-L104">CmdColumnRound.cs</a>, cf. the <a href="https://github.com/jeremytammik/the_building_coder_samples/compare/2017.0.131.0...2017.0.131.1">diff from the previous release</a>.</p>
+<a href="https://github.com/jeremytammik/the_building_coder_samples/releases/tag/2017.0.131.1">release 2017.0.131.1</a> in the module  <a href="https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/CmdColumnRound.cs#L30-L104">CmdColumnRound.cs</a>, cf. the <a href="https://github.com/jeremytammik/the_building_coder_samples/compare/2017.0.131.0...2017.0.131.1">diff from the previous release</a>.</p>
     </article>
     <div class="nav">
         <a href="index.html">← Back to Index</a>

--- a/a/1493_au_2017_1_sdk_freeze.md
+++ b/a/1493_au_2017_1_sdk_freeze.md
@@ -284,4 +284,4 @@ Thanks to Jim for sharing these snippets!
 
 I also added them 
 to [The Building Coder samples](https://github.com/jeremytammik/the_building_coder_samples)
-[release 2017.0.131.1](https://github.com/jeremytammik/the_building_coder_samples/releases/tag/2017.0.131.1) in the module  [CmdColumnRound.cs](https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/BuildingCoder/CmdColumnRound.cs#L30-L104), cf. the [diff from the previous release](https://github.com/jeremytammik/the_building_coder_samples/compare/2017.0.131.0...2017.0.131.1).
+[release 2017.0.131.1](https://github.com/jeremytammik/the_building_coder_samples/releases/tag/2017.0.131.1) in the module  [CmdColumnRound.cs](https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/CmdColumnRound.cs#L30-L104), cf. the [diff from the previous release](https://github.com/jeremytammik/the_building_coder_samples/compare/2017.0.131.0...2017.0.131.1).

--- a/a/1504_views_showing_element.html
+++ b/a/1504_views_showing_element.html
@@ -87,7 +87,7 @@ with Erik sharing a <code>View</code> extension method <code>IntersectsBoundingB
 <li><a href="1158_views_displaying_elem.htm#6">Determine Views Displaying Given Element</a></li>
 <li><a href="http://forums.autodesk.com/t5/Revit-API/Revision-help-which-views-show-this-object/m-p/5029772">Revision help: which views show this object?</a></li>
 <li><a href="https://github.com/jeremytammik/the_building_coder_samples">The Building Coder samples GitHub repository</a><ul>
-<li><a href="https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/BuildingCoder/CmdViewsShowingElements.cs"><code>CmdViewsShowingElements</code></a></li>
+<li><a href="https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/CmdViewsShowingElements.cs"><code>CmdViewsShowingElements</code></a></li>
 </ul>
 </li>
 </ul>
@@ -315,7 +315,7 @@ It's just another way of doing it, maybe they don't do it because they too know 
 <p>I added Erik's <code>View</code> extension method <code>IntersectsBoundingBox</code> 
 to <a href="https://github.com/jeremytammik/the_building_coder_samples">The Building Coder samples</a>
 <a href="https://github.com/jeremytammik/the_building_coder_samples/releases/tag/2017.0.131.3">release 2017.0.131.3</a> in the
-module <a href="https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/BuildingCoder/CmdViewsShowingElements.cs">CmdViewsShowingElements.cs</a>,
+module <a href="https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/CmdViewsShowingElements.cs">CmdViewsShowingElements.cs</a>,
 in case anyone else would like to play with it.</p>
     </article>
     <div class="nav">

--- a/a/1504_views_showing_element.md
+++ b/a/1504_views_showing_element.md
@@ -66,7 +66,7 @@ This one, we can answer, and already have, including a dedicated external comman
 - [Determine Views Displaying Given Element](1158_views_displaying_elem.htm#6)
 - [Revision help: which views show this object?](http://forums.autodesk.com/t5/Revit-API/Revision-help-which-views-show-this-object/m-p/5029772)
 - [The Building Coder samples GitHub repository](https://github.com/jeremytammik/the_building_coder_samples)
-    - [`CmdViewsShowingElements`](https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/BuildingCoder/CmdViewsShowingElements.cs)
+    - [`CmdViewsShowingElements`](https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/CmdViewsShowingElements.cs)
     
 
 ####<a name="4"></a>Response
@@ -370,5 +370,5 @@ Here are some pretty old and rudimentary introductions to the topics that you as
 I added Erik's `View` extension method `IntersectsBoundingBox` 
 to [The Building Coder samples](https://github.com/jeremytammik/the_building_coder_samples)
 [release 2017.0.131.3](https://github.com/jeremytammik/the_building_coder_samples/releases/tag/2017.0.131.3) in the
-module [CmdViewsShowingElements.cs](https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/BuildingCoder/CmdViewsShowingElements.cs),
+module [CmdViewsShowingElements.cs](https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/CmdViewsShowingElements.cs),
 in case anyone else would like to play with it.

--- a/a/1509_viewport_bring_front.html
+++ b/a/1509_viewport_bring_front.html
@@ -142,7 +142,7 @@ suggesting:</p>
 <li>Commented out unused variables.</li>
 </ul>
 <p>I added this method to <a href="https://github.com/jeremytammik/the_building_coder_samples">The Building Coder samples</a> in the
-<a href="https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/BuildingCoder/CmdViewsShowingElements.cs#L424-L449">module CmdViewsShowingElements.cs line 424-449</a>.</p>
+<a href="https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/CmdViewsShowingElements.cs#L424-L449">module CmdViewsShowingElements.cs line 424-449</a>.</p>
 <p>Very many thanks to Joshua for sharing this and putting in all the work to document it, edit the draft markdown file and create
 a <a href="https://github.com/jeremytammik/tbc/pull/1">pull request</a> for it in
 the <a href="https://github.com/jeremytammik/tbc">tbc GitHub repo</a>!</p>

--- a/a/1509_viewport_bring_front.md
+++ b/a/1509_viewport_bring_front.md
@@ -128,7 +128,7 @@ Notes:
 - Commented out unused variables.
 
 I added this method to [The Building Coder samples](https://github.com/jeremytammik/the_building_coder_samples) in the
-[module CmdViewsShowingElements.cs line 424-449](https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/BuildingCoder/CmdViewsShowingElements.cs#L424-L449).
+[module CmdViewsShowingElements.cs line 424-449](https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/CmdViewsShowingElements.cs#L424-L449).
 
 Very many thanks to Joshua for sharing this and putting in all the work to document it, edit the draft markdown file and create
 a [pull request](https://github.com/jeremytammik/tbc/pull/1) for it in

--- a/a/1521_wall_opening_areas.html
+++ b/a/1521_wall_opening_areas.html
@@ -100,7 +100,7 @@ in <a href="https://github.com/jeremytammik/AdnRevitApiLabsXtra/blob/master/Xtra
 <p>For future reference, I implemented two new helper methods <code>FamilyFirstSymbolCategoryEquals</code> and <code>GetFamiliesOfCategory</code>
 in <a href="https://github.com/jeremytammik/the_building_coder_samples">The Building Coder samples</a> to
 demonstrate this, in the
-module <a href="https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/BuildingCoder/CmdCollectorPerformance.cs#L292-L330">CmdCollectorPerformance.cs, lines 292-L330</a>:</p>
+module <a href="https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/CmdCollectorPerformance.cs#L292-L330">CmdCollectorPerformance.cs, lines 292-L330</a>:</p>
 <pre class="code">
 <span style="color:blue;">static</span>&nbsp;<span style="color:blue;">bool</span>&nbsp;FamilyFirstSymbolCategoryEquals(
 &nbsp;&nbsp;<span style="color:#2b91af;">Family</span>&nbsp;f,&nbsp;

--- a/a/1521_wall_opening_areas.md
+++ b/a/1521_wall_opening_areas.md
@@ -78,7 +78,7 @@ in [lines 86-118](https://github.com/jeremytammik/AdnRevitApiLabsXtra/blob/maste
 For future reference, I implemented two new helper methods `FamilyFirstSymbolCategoryEquals` and `GetFamiliesOfCategory`
 in [The Building Coder samples](https://github.com/jeremytammik/the_building_coder_samples) to
 demonstrate this, in the
-module [CmdCollectorPerformance.cs, lines 292-L330](https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/BuildingCoder/CmdCollectorPerformance.cs#L292-L330):
+module [CmdCollectorPerformance.cs, lines 292-L330](https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/CmdCollectorPerformance.cs#L292-L330):
 
 <pre class="code">
 <span style="color:blue;">static</span>&nbsp;<span style="color:blue;">bool</span>&nbsp;FamilyFirstSymbolCategoryEquals(

--- a/a/1556_prompt_exception.html
+++ b/a/1556_prompt_exception.html
@@ -152,7 +152,7 @@ on <a href="1551_whats_new_2018.html#2.7">UIDocument.PromptForFamilyInstancePlac
 <p>I hope this clarifies and all is now illuminated.</p>
 <h4><a name="7"></a>The Building Coder Samples CmdPlaceFamilyInstance</h4>
 <p>I implemented
-the <a href="https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/BuildingCoder/CmdPlaceFamilyInstance.cs">external command CmdPlaceFamilyInstance</a>
+the <a href="https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/CmdPlaceFamilyInstance.cs">external command CmdPlaceFamilyInstance</a>
 in <a href="https://github.com/jeremytammik/the_building_coder_samples">The Building Coder samples</a> to
 exercise the <code>PromptForFamilyInstancePlacement</code> method when it was originally introduced.</p>
 <p>It also includes code using the <code>DocumentChanged</code> event

--- a/a/1556_prompt_exception.md
+++ b/a/1556_prompt_exception.md
@@ -173,7 +173,7 @@ I hope this clarifies and all is now illuminated.
 #### <a name="7"></a>The Building Coder Samples CmdPlaceFamilyInstance
 
 I implemented
-the [external command CmdPlaceFamilyInstance](https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/BuildingCoder/CmdPlaceFamilyInstance.cs)
+the [external command CmdPlaceFamilyInstance](https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/CmdPlaceFamilyInstance.cs)
 in [The Building Coder samples](https://github.com/jeremytammik/the_building_coder_samples) to
 exercise the `PromptForFamilyInstancePlacement` method when it was originally introduced.
 

--- a/a/1561_elem_visible_view.html
+++ b/a/1561_elem_visible_view.html
@@ -49,7 +49,7 @@ Below is the utility function I use to achieve this. Note this works for any ele
 ...
 The category filter is used to eliminate any element not of the desired category before using the slower parameter filter to find the desired element. It is probably possible to speed this up further with clever usage of filters, but I have found that it is plenty fast enough for me in practice.
 Colin Stark
-Thank you for that, Colin! I added it to [The Building Coder samples](https://github.com/jeremytammik/the_building_coder_samples) [CmdViewsShowingElements](https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/BuildingCoder/CmdViewsShowingElements.cs), described in the discussion of [Determining Views Showing an Element](1504_views_showing_element.html
+Thank you for that, Colin! I added it to [The Building Coder samples](https://github.com/jeremytammik/the_building_coder_samples) [CmdViewsShowingElements](https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/CmdViewsShowingElements.cs), described in the discussion of [Determining Views Showing an Element](1504_views_showing_element.html
 
 - CmdViewsShowingElements
   - [Determine Views Displaying Given Element](1158_views_displaying_elem.htm#6)
@@ -111,7 +111,7 @@ to <a href="http://stackoverflow.com/questions/44012630/determine-is-a-familyins
 <p>The category filter is used to eliminate any element not of the desired category before using the slower parameter filter to find the desired element. It is probably possible to speed this up further with clever usage of filters, but I have found that it is plenty fast enough for me in practice.</p>
 </blockquote>
 <p>I added Colin's code to <a href="https://github.com/jeremytammik/the_building_coder_samples">The Building Coder samples</a>
-module <a href="https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/BuildingCoder/CmdViewsShowingElements.cs">CmdViewsShowingElement</a>.</p>
+module <a href="https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/CmdViewsShowingElements.cs">CmdViewsShowingElement</a>.</p>
 <pre class="code">
 &nbsp;&nbsp;&nbsp;<span style="color:gray;">///</span><span style="color:green;">&nbsp;</span><span style="color:gray;">&lt;</span><span style="color:gray;">summary</span><span style="color:gray;">&gt;</span>
 &nbsp;&nbsp;<span style="color:gray;">///</span><span style="color:green;">&nbsp;Determine&nbsp;whether&nbsp;an&nbsp;element&nbsp;is&nbsp;visible&nbsp;in&nbsp;a&nbsp;view,&nbsp;</span>

--- a/a/1561_elem_visible_view.md
+++ b/a/1561_elem_visible_view.md
@@ -18,7 +18,7 @@ Below is the utility function I use to achieve this. Note this works for any ele
 ...
 The category filter is used to eliminate any element not of the desired category before using the slower parameter filter to find the desired element. It is probably possible to speed this up further with clever usage of filters, but I have found that it is plenty fast enough for me in practice.
 Colin Stark
-Thank you for that, Colin! I added it to [The Building Coder samples](https://github.com/jeremytammik/the_building_coder_samples) [CmdViewsShowingElements](https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/BuildingCoder/CmdViewsShowingElements.cs), described in the discussion of [Determining Views Showing an Element](1504_views_showing_element.html).
+Thank you for that, Colin! I added it to [The Building Coder samples](https://github.com/jeremytammik/the_building_coder_samples) [CmdViewsShowingElements](https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/CmdViewsShowingElements.cs), described in the discussion of [Determining Views Showing an Element](1504_views_showing_element.html).
 
 - CmdViewsShowingElements
   - [Determine Views Displaying Given Element](1158_views_displaying_elem.htm#6)
@@ -103,7 +103,7 @@ Colin Stark answered that succinctly, saying:
 > The category filter is used to eliminate any element not of the desired category before using the slower parameter filter to find the desired element. It is probably possible to speed this up further with clever usage of filters, but I have found that it is plenty fast enough for me in practice.
  
 I added Colin's code to [The Building Coder samples](https://github.com/jeremytammik/the_building_coder_samples)
-module [CmdViewsShowingElement](https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/BuildingCoder/CmdViewsShowingElements.cs).
+module [CmdViewsShowingElement](https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/CmdViewsShowingElements.cs).
 
 <pre class="code">
 &nbsp;&nbsp;&nbsp;<span style="color:gray;">///</span><span style="color:green;">&nbsp;</span><span style="color:gray;">&lt;</span><span style="color:gray;">summary</span><span style="color:gray;">&gt;</span>

--- a/a/1562_mod_grid_point.html
+++ b/a/1562_mod_grid_point.html
@@ -165,7 +165,7 @@ it stands now, up and running on my system.</p>
 <p>I added Ryuji's sample as a new external command
 to <a href="https://github.com/jeremytammik/the_building_coder_samples">The Building Coder samples</a>
 <a href="https://github.com/jeremytammik/the_building_coder_samples/releases/tag/2018.0.133.0">release 2018.0.133.0</a> in the
-module <a href="https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/BuildingCoder/CmdSetGridEndpoint.cs">CmdSetGridEndpoint.cs</a>.</p>
+module <a href="https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/CmdSetGridEndpoint.cs">CmdSetGridEndpoint.cs</a>.</p>
 <p>Here are the isolated grids in <em>rac_basic_sample.rvt</em>:</p>
 <p><center>
 <img src="img/rac_basic_sample_project_grids.png" alt="Grids in rac_basic_sample.rvt" width="329">

--- a/a/1562_mod_grid_point.md
+++ b/a/1562_mod_grid_point.md
@@ -163,7 +163,7 @@ It moves the grid endpoints vertically, so you need to select a vertically orien
 I added Ryuji's sample as a new external command
 to [The Building Coder samples](https://github.com/jeremytammik/the_building_coder_samples)
 [release 2018.0.133.0](https://github.com/jeremytammik/the_building_coder_samples/releases/tag/2018.0.133.0) in the
-module [CmdSetGridEndpoint.cs](https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/BuildingCoder/CmdSetGridEndpoint.cs).
+module [CmdSetGridEndpoint.cs](https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/CmdSetGridEndpoint.cs).
 
 Here are the isolated grids in *rac_basic_sample.rvt*:
 

--- a/a/1566_align_grid.html
+++ b/a/1566_align_grid.html
@@ -43,7 +43,7 @@
 - rotate grid to horizontal or vertical
   13048285 [Grids Off-Axis]
   https://forums.autodesk.com/t5/revit-api-forum/grids-off-axis/m-p/7129065
-  https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/BuildingCoder/CmdSetGridEndpoint.cs
+  https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/CmdSetGridEndpoint.cs
 
 Aligning a Slightly Off-Axis Grid using #RevitAPI @AutodeskRevit #bim #dynamobim @AutodeskForge #ForgeDevCon http://bit.ly/aligngrid
 
@@ -145,7 +145,7 @@ However, on grids that are microscopically off-axis, it fails, saying "The curve
 <p>Many thanks to Fair59 for this efficient solution!</p>
 <p>I added it 
 to <a href="https://github.com/jeremytammik/the_building_coder_samples">The Building Coder samples</a>
-module <a href="https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/BuildingCoder/CmdSetGridEndpoint.cs">CmdSetGridEndpoint.cs</a>
+module <a href="https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/CmdSetGridEndpoint.cs">CmdSetGridEndpoint.cs</a>
 in <a href="https://github.com/jeremytammik/the_building_coder_samples/releases/tag/2018.0.133.1">release 2018.0.133.1</a>,
 cf. the <a href="https://github.com/jeremytammik/the_building_coder_samples/compare/2018.0.133.0...2018.0.133.1">diff to the previous version</a>.</p>
     </article>

--- a/a/1566_align_grid.md
+++ b/a/1566_align_grid.md
@@ -12,7 +12,7 @@
 - rotate grid to horizontal or vertical
   13048285 [Grids Off-Axis]
   https://forums.autodesk.com/t5/revit-api-forum/grids-off-axis/m-p/7129065
-  https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/BuildingCoder/CmdSetGridEndpoint.cs
+  https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/CmdSetGridEndpoint.cs
 
 Aligning a Slightly Off-Axis Grid using #RevitAPI @AutodeskRevit #bim #dynamobim @AutodeskForge #ForgeDevCon http://bit.ly/aligngrid
 
@@ -131,7 +131,7 @@ Many thanks to Fair59 for this efficient solution!
 
 I added it 
 to [The Building Coder samples](https://github.com/jeremytammik/the_building_coder_samples)
-module [CmdSetGridEndpoint.cs](https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/BuildingCoder/CmdSetGridEndpoint.cs)
+module [CmdSetGridEndpoint.cs](https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/CmdSetGridEndpoint.cs)
 in [release 2018.0.133.1](https://github.com/jeremytammik/the_building_coder_samples/releases/tag/2018.0.133.1),
 cf. the [diff to the previous version](https://github.com/jeremytammik/the_building_coder_samples/compare/2018.0.133.0...2018.0.133.1).
 

--- a/a/1568_dim_seg_points.html
+++ b/a/1568_dim_seg_points.html
@@ -43,7 +43,7 @@
 - dimension segment endpoints
   13073404 [How to retrieve a Dimension's (segment) geometry ?] 
   https://forums.autodesk.com/t5/revit-api-forum/how-to-retrieve-a-dimension-s-segment-geometry/m-p/7145688
-  https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/BuildingCoder/CmdGetDimensionPoints.cs
+  https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/CmdGetDimensionPoints.cs
 
 Determining Dimension Segment Endoints #RevitAPI @AutodeskRevit #bim #dynamobim @AutodeskForge #ForgeDevCon http://bit.ly/dimsegendpt
 
@@ -68,7 +68,7 @@ A rather hard struggle led to a rather simple solution for determining the start
 <li>In the case of multiple segments, use an analogue approach on each individual segment.</li>
 </ul>
 <p>I implemented and added a new external
-command <a href="https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/BuildingCoder/CmdGetDimensionPoints.cs">CmdGetDimensionPoints</a>
+command <a href="https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/CmdGetDimensionPoints.cs">CmdGetDimensionPoints</a>
 to <a href="https://github.com/jeremytammik/the_building_coder_samples">The Building Coder samples</a>
 I added it 
 to <a href="https://github.com/jeremytammik/the_building_coder_samples">The Building Coder samples</a>

--- a/a/1568_dim_seg_points.md
+++ b/a/1568_dim_seg_points.md
@@ -12,7 +12,7 @@
 - dimension segment endpoints
   13073404 [How to retrieve a Dimension's (segment) geometry ?] 
   https://forums.autodesk.com/t5/revit-api-forum/how-to-retrieve-a-dimension-s-segment-geometry/m-p/7145688
-  https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/BuildingCoder/CmdGetDimensionPoints.cs
+  https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/CmdGetDimensionPoints.cs
 
 Determining Dimension Segment Endoints #RevitAPI @AutodeskRevit #bim #dynamobim @AutodeskForge #ForgeDevCon http://bit.ly/dimsegendpt
 
@@ -38,7 +38,7 @@ In summary, the solution looks like this:
 - In the case of multiple segments, use an analogue approach on each individual segment.
 
 I implemented and added a new external
-command [CmdGetDimensionPoints](https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/BuildingCoder/CmdGetDimensionPoints.cs)
+command [CmdGetDimensionPoints](https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/CmdGetDimensionPoints.cs)
 to [The Building Coder samples](https://github.com/jeremytammik/the_building_coder_samples)
 I added it 
 to [The Building Coder samples](https://github.com/jeremytammik/the_building_coder_samples)

--- a/a/1578_fam_filt_forge_aec.html
+++ b/a/1578_fam_filt_forge_aec.html
@@ -241,7 +241,7 @@ to <a href="1382_filter_shortcuts.html">apply all quick filters first</a>.</p>
 and <a href="0832_find_element_optimise.htm">may cause a significant inefficiency</a>.</p>
 <p>Check out the examples provided
 by <a href="https://github.com/jeremytammik/the_building_coder_samples">The Building Coder samples</a> in
-the <a href="https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/BuildingCoder/CmdCollectorPerformance.cs">module CmdCollectorPerformance.cs</a></p>
+the <a href="https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/CmdCollectorPerformance.cs">module CmdCollectorPerformance.cs</a></p>
 <p>You could filter for families first, then determine their types, and then the instances referring to those.</p>
 <p>In fact, the CmdCollectorPerformance.cs module includes code demonstrating that approach.</p>
 <p>However, since the elements you are after in the end are the instances, it makes sense to filter for those right away, and then eliminate the ones that don't match the expected family.</p>
@@ -287,7 +287,7 @@ the <a href="https://github.com/jeremytammik/the_building_coder_samples/blob/mas
 </pre>
 
 <p>Implementing dedicated parameter filters for the family and type name would be much more efficient, and would avoid Revit having to marshal and send across to .NET all the data for the instances or types that do not match the desired criteria.</p>
-<p>The code region to <a href="https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/BuildingCoder/CmdCollectorPerformance.cs#L1039-L1101">retrieve named family symbols</a> demonstrates several different approaches using both LINQ and the more efficient parameter filter.</p>
+<p>The code region to <a href="https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/CmdCollectorPerformance.cs#L1039-L1101">retrieve named family symbols</a> demonstrates several different approaches using both LINQ and the more efficient parameter filter.</p>
 <p>You can implement similar code to retrieve family instances instead of symbols.</p>
     </article>
     <div class="nav">

--- a/a/1578_fam_filt_forge_aec.md
+++ b/a/1578_fam_filt_forge_aec.md
@@ -263,7 +263,7 @@ and [may cause a significant inefficiency](0832_find_element_optimise.htm).
  
 Check out the examples provided
 by [The Building Coder samples](https://github.com/jeremytammik/the_building_coder_samples) in
-the [module CmdCollectorPerformance.cs](https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/BuildingCoder/CmdCollectorPerformance.cs)
+the [module CmdCollectorPerformance.cs](https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/CmdCollectorPerformance.cs)
  
 You could filter for families first, then determine their types, and then the instances referring to those.
  
@@ -315,7 +315,7 @@ Here are the two functions using LINQ post-processing that I now added to The Bu
 
 Implementing dedicated parameter filters for the family and type name would be much more efficient, and would avoid Revit having to marshal and send across to .NET all the data for the instances or types that do not match the desired criteria.
 
-The code region to [retrieve named family symbols](https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/BuildingCoder/CmdCollectorPerformance.cs#L1039-L1101) demonstrates several different approaches using both LINQ and the more efficient parameter filter.
+The code region to [retrieve named family symbols](https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/CmdCollectorPerformance.cs#L1039-L1101) demonstrates several different approaches using both LINQ and the more efficient parameter filter.
  
 You can implement similar code to retrieve family instances instead of symbols.
  

--- a/a/1580_bday_xyz_point_vector.html
+++ b/a/1580_bday_xyz_point_vector.html
@@ -299,7 +299,7 @@ at <a href="https://github.com/jeremytammik/the_building_coder_samples">The Buil
 </pre>
 
 <p>Yet another solution to address this directly is to define a comparer class for native Revit API <code>Connector</code> objects, such as the <code>ConnectorXyzComparer</code> one provided in
-at <a href="https://github.com/jeremytammik/the_building_coder_samples">The Building Coder samples</a> <a href="https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/BuildingCoder/Util.cs#L1439-L1465">Util.cs  module</a>:</p>
+at <a href="https://github.com/jeremytammik/the_building_coder_samples">The Building Coder samples</a> <a href="https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/Util.cs#L1439-L1465">Util.cs  module</a>:</p>
 <pre class="code">
 <span style="color:gray;">///</span><span style="color:green;">&nbsp;</span><span style="color:gray;">&lt;</span><span style="color:gray;">summary</span><span style="color:gray;">&gt;</span>
 <span style="color:gray;">///</span><span style="color:green;">&nbsp;Compare&nbsp;Connector&nbsp;objects&nbsp;based&nbsp;on&nbsp;their&nbsp;location&nbsp;point.</span>

--- a/a/1580_bday_xyz_point_vector.md
+++ b/a/1580_bday_xyz_point_vector.md
@@ -318,7 +318,7 @@ Storing `Point3D` instances in a hashset will give you your distinct set of poin
 </pre>
 
 Yet another solution to address this directly is to define a comparer class for native Revit API `Connector` objects, such as the `ConnectorXyzComparer` one provided in
-at [The Building Coder samples](https://github.com/jeremytammik/the_building_coder_samples) [Util.cs  module](https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/BuildingCoder/Util.cs#L1439-L1465):
+at [The Building Coder samples](https://github.com/jeremytammik/the_building_coder_samples) [Util.cs  module](https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/Util.cs#L1439-L1465):
 
 <pre class="code">
 <span style="color:gray;">///</span><span style="color:green;">&nbsp;</span><span style="color:gray;">&lt;</span><span style="color:gray;">summary</span><span style="color:gray;">&gt;</span>

--- a/a/1581_edge_refplane_column.html
+++ b/a/1581_edge_refplane_column.html
@@ -337,7 +337,7 @@ to <a href="https://github.com/jeremytammik/the_building_coder_samples">The Buil
 
 <p>I added them
 to <a href="https://github.com/jeremytammik/the_building_coder_samples/releases/tag/2018.0.134.3">The Building Coder samples release 2018.0.134.3</a>
-module <a href="https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/BuildingCoder/CmdSlabBoundaryArea.cs#L29-L102">CmdSlabBoundaryArea.cs L29-L102</a>.</p>
+module <a href="https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/CmdSlabBoundaryArea.cs#L29-L102">CmdSlabBoundaryArea.cs L29-L102</a>.</p>
 <p>Many thanks to Richard for implementing, testing and sharing this simple approach!</p>
 <h4><a name="4"></a>How to Determine the Location Curve for a Steel Column</h4>
 <p>Richard also answered 

--- a/a/1581_edge_refplane_column.md
+++ b/a/1581_edge_refplane_column.md
@@ -331,7 +331,7 @@ Instead of using `C.Evaluate` twenty times over, I call the curve `Tessellate` m
  
 I added them
 to [The Building Coder samples release 2018.0.134.3](https://github.com/jeremytammik/the_building_coder_samples/releases/tag/2018.0.134.3)
-module [CmdSlabBoundaryArea.cs L29-L102](https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/BuildingCoder/CmdSlabBoundaryArea.cs#L29-L102).
+module [CmdSlabBoundaryArea.cs L29-L102](https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/CmdSlabBoundaryArea.cs#L29-L102).
  
 Many thanks to Richard for implementing, testing and sharing this simple approach!
 

--- a/a/1592_disjunct_outer_loops.html
+++ b/a/1592_disjunct_outer_loops.html
@@ -359,7 +359,7 @@ on <a href="https://forums.autodesk.com/t5/revit-api-forum/outer-loops-of-planar
 
 <p>I added the latter 
 to <a href="https://github.com/jeremytammik/the_building_coder_samples/releases/tag/2018.0.134.4">The Building Coder samples release 2018.0.134.4</a>
-module <a href="https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/BuildingCoder/CmdSlabBoundaryArea.cs#L29-L176">CmdSlabBoundaryArea.cs L29-L176</a>.</p>
+module <a href="https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/CmdSlabBoundaryArea.cs#L29-L176">CmdSlabBoundaryArea.cs L29-L176</a>.</p>
 <p>Many thanks to Richard for implementing, testing and sharing this improved solution!</p>
     </article>
     <div class="nav">

--- a/a/1592_disjunct_outer_loops.md
+++ b/a/1592_disjunct_outer_loops.md
@@ -340,6 +340,6 @@ I've tested this solution on some interesting slab shapes shown below and result
  
 I added the latter 
 to [The Building Coder samples release 2018.0.134.4](https://github.com/jeremytammik/the_building_coder_samples/releases/tag/2018.0.134.4)
-module [CmdSlabBoundaryArea.cs L29-L176](https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/BuildingCoder/CmdSlabBoundaryArea.cs#L29-L176).
+module [CmdSlabBoundaryArea.cs L29-L176](https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/CmdSlabBoundaryArea.cs#L29-L176).
  
 Many thanks to Richard for implementing, testing and sharing this improved solution!

--- a/a/1597_curtain_wall_panel.html
+++ b/a/1597_curtain_wall_panel.html
@@ -96,7 +96,7 @@ I am struggling to retrieve the geometry data from a curtain wall that contains 
 
 <p>I added this code in the method <code>GetCurtainWallPanelGeometry</code> 
 to <a href="https://github.com/jeremytammik/the_building_coder_samples/releases/tag/2018.0.134.6">The Building Coder samples release 2018.0.134.6</a>
-module <a href="https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/BuildingCoder/CmdCurtainWallGeom.cs#L35-L66">CmdCurtainWallGeom.cs L35-L66</a>.</p>
+module <a href="https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/CmdCurtainWallGeom.cs#L35-L66">CmdCurtainWallGeom.cs L35-L66</a>.</p>
     </article>
     <div class="nav">
         <a href="index.html">← Back to Index</a>

--- a/a/1597_curtain_wall_panel.md
+++ b/a/1597_curtain_wall_panel.md
@@ -72,5 +72,5 @@ The main point is this: we need to find the panel-wall which corresponds to the 
 
 I added this code in the method `GetCurtainWallPanelGeometry` 
 to [The Building Coder samples release 2018.0.134.6](https://github.com/jeremytammik/the_building_coder_samples/releases/tag/2018.0.134.6)
-module [CmdCurtainWallGeom.cs L35-L66](https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/BuildingCoder/CmdCurtainWallGeom.cs#L35-L66).
+module [CmdCurtainWallGeom.cs L35-L66](https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/CmdCurtainWallGeom.cs#L35-L66).
  

--- a/a/1608_create_mass_floor.html
+++ b/a/1608_create_mass_floor.html
@@ -92,7 +92,7 @@ on <a href="https://youtu.be/nHWen2_lN6U">Face Wall and Mass Floor creation with
 <p>The API calls are driven by Harry's C# .NET Revit API macro <code>CreateFaceWallsAndMassFloors</code>.</p>
 <p>Here is the code copied from Harry's post and added
 to <a href="https://github.com/jeremytammik/the_building_coder_samples">The Building Coder samples</a>
-in <a href="https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/BuildingCoder/CmdFaceWall.cs#L414-L473">lines 414-473 of CmdFaceWall.cs</a>:</p>
+in <a href="https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/CmdFaceWall.cs#L414-L473">lines 414-473 of CmdFaceWall.cs</a>:</p>
 <pre class="code">
 <span style="color:blue;">#region</span>&nbsp;CreateFaceWallsAndMassFloors
 <span style="color:green;">//&nbsp;By&nbsp;Harry&nbsp;Mattison,&nbsp;Boost&nbsp;Your&nbsp;BIM,</span>

--- a/a/1608_create_mass_floor.md
+++ b/a/1608_create_mass_floor.md
@@ -78,7 +78,7 @@ The API calls are driven by Harry's C# .NET Revit API macro `CreateFaceWallsAndM
 
 Here is the code copied from Harry's post and added
 to [The Building Coder samples](https://github.com/jeremytammik/the_building_coder_samples)
-in [lines 414-473 of CmdFaceWall.cs](https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/BuildingCoder/CmdFaceWall.cs#L414-L473):
+in [lines 414-473 of CmdFaceWall.cs](https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/CmdFaceWall.cs#L414-L473):
 
 <pre class="code">
 <span style="color:blue;">#region</span>&nbsp;CreateFaceWallsAndMassFloors

--- a/a/1612_param_vary_group.html
+++ b/a/1612_param_vary_group.html
@@ -194,7 +194,7 @@ to <a href="0754_shared_param_add_categ.htm">add a category to a shared paramete
 
 <p>I added Miro's method <code>SetInstanceParamVaryBetweenGroupsBehaviour</code> 
 to <a href="https://github.com/jeremytammik/the_building_coder_samples/releases/tag/2018.0.134.11">The Building Coder samples release 2018.0.134.11</a> in
-the module <a href="https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/BuildingCoder/CmdCreateSharedParams.cs#L441-L470">CmdCreateSharedParams.cs L441-L470</a>.</p>
+the module <a href="https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/CmdCreateSharedParams.cs#L441-L470">CmdCreateSharedParams.cs L441-L470</a>.</p>
 <p>Many thanks to Miro for raising this issue and sharing his approach to solve it!</p>
     </article>
     <div class="nav">

--- a/a/1612_param_vary_group.md
+++ b/a/1612_param_vary_group.md
@@ -182,6 +182,6 @@ Here is a code snippet providing enough to get the gist of how the above can be 
 
 I added Miro's method `SetInstanceParamVaryBetweenGroupsBehaviour` 
 to [The Building Coder samples release 2018.0.134.11](https://github.com/jeremytammik/the_building_coder_samples/releases/tag/2018.0.134.11) in
-the module [CmdCreateSharedParams.cs L441-L470](https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/BuildingCoder/CmdCreateSharedParams.cs#L441-L470).
+the module [CmdCreateSharedParams.cs L441-L470](https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/CmdCreateSharedParams.cs#L441-L470).
 
 Many thanks to Miro for raising this issue and sharing his approach to solve it!

--- a/a/1616_devdays_webinars.html
+++ b/a/1616_devdays_webinars.html
@@ -171,7 +171,7 @@ be <a href="1154_directshape_min_size.htm">at least about 2 mm apart</a>.</p>
 <p>While reading the input vertices one by one, I put them into a dictionary equipped with an <code>XYZ</code> comparison operator.</p>
 <p>If a new vertex is very close to an existing one, my comparison operator considers the two vertices to be equal, so I ignore it and use the existing one instead.</p>
 <p>The <code>GetVertices</code> method
-in <a href="https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/BuildingCoder/CmdNestedInstanceGeo.cs#L30-L85">The Building Coder samples CmdNestedInstanceGeo.cs</a> does
+in <a href="https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/CmdNestedInstanceGeo.cs#L30-L85">The Building Coder samples CmdNestedInstanceGeo.cs</a> does
 something similar using an <code>XyzEqualityComparer</code>.</p>
 <p>You would simply have to replace the face vertex index of any ignored vertex by the index of its replacement.</p>
 <p>There is also an <code>Appliation.MinimumThickness</code> property. It says in

--- a/a/1616_devdays_webinars.md
+++ b/a/1616_devdays_webinars.md
@@ -175,7 +175,7 @@ While reading the input vertices one by one, I put them into a dictionary equipp
 If a new vertex is very close to an existing one, my comparison operator considers the two vertices to be equal, so I ignore it and use the existing one instead.
 
 The `GetVertices` method
-in [The Building Coder samples CmdNestedInstanceGeo.cs](https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/BuildingCoder/CmdNestedInstanceGeo.cs#L30-L85) does
+in [The Building Coder samples CmdNestedInstanceGeo.cs](https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/CmdNestedInstanceGeo.cs#L30-L85) does
 something similar using an `XyzEqualityComparer`.
 
 You would simply have to replace the face vertex index of any ignored vertex by the index of its replacement.

--- a/a/1621_return_failure_info.html
+++ b/a/1621_return_failure_info.html
@@ -305,7 +305,7 @@ on <a href="https://forums.autodesk.com/t5/revit-api-forum/return-failure-inform
 to <a href="https://github.com/jeremytammik/the_building_coder_samples">The Building Coder Samples</a> 
 <a href="https://github.com/jeremytammik/the_building_coder_samples/releases/tag/2018.0.135.1">release 2018.0.135.1</a>
 in the new module 
-<a href="https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/BuildingCoder/CmdFailureGatherer.cs">CmdFailureGatherer.cs</a>.</p>
+<a href="https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/CmdFailureGatherer.cs">CmdFailureGatherer.cs</a>.</p>
 <p>In that command, I generate a warning by creating two overlapping walls:</p>
 <pre class="code">
   <span style="color:green;">//&nbsp;Generate&nbsp;an&nbsp;&#39;duplicate&nbsp;wall&#39;&nbsp;warning&nbsp;message:</span>

--- a/a/1621_return_failure_info.md
+++ b/a/1621_return_failure_info.md
@@ -299,7 +299,7 @@ I added it
 to [The Building Coder Samples](https://github.com/jeremytammik/the_building_coder_samples) 
 [release 2018.0.135.1](https://github.com/jeremytammik/the_building_coder_samples/releases/tag/2018.0.135.1)
 in the new module 
-[CmdFailureGatherer.cs](https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/BuildingCoder/CmdFailureGatherer.cs).
+[CmdFailureGatherer.cs](https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/CmdFailureGatherer.cs).
 
 In that command, I generate a warning by creating two overlapping walls:
 

--- a/a/1622_get_crop_box_for_view.html
+++ b/a/1622_get_crop_box_for_view.html
@@ -98,7 +98,7 @@ E.g., the crop box 'points' to the id of the view it is in using <code>ID_PARAM<
 to <a href="https://github.com/jeremytammik/the_building_coder_samples">The Building Coder Samples</a> 
 <a href="https://github.com/jeremytammik/the_building_coder_samples/releases/tag/2018.0.135.2">release 2018.0.135.2</a> and
 the extensive collection of filtered element examples in 
-the <a href="https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/BuildingCoder/CmdCollectorPerformance.cs">module CmdCollectorPerformance.cs</a>:</p>
+the <a href="https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/CmdCollectorPerformance.cs">module CmdCollectorPerformance.cs</a>:</p>
 <pre class="code">
   <span style="color:gray;">///</span><span style="color:green;">&nbsp;</span><span style="color:gray;">&lt;</span><span style="color:gray;">summary</span><span style="color:gray;">&gt;</span>
   <span style="color:gray;">///</span><span style="color:green;">&nbsp;Return&nbsp;element&nbsp;id&nbsp;of&nbsp;crop&nbsp;box&nbsp;for&nbsp;a&nbsp;given&nbsp;view.</span>

--- a/a/1622_get_crop_box_for_view.md
+++ b/a/1622_get_crop_box_for_view.md
@@ -79,7 +79,7 @@ I ported it to C# and added it
 to [The Building Coder Samples](https://github.com/jeremytammik/the_building_coder_samples) 
 [release 2018.0.135.2](https://github.com/jeremytammik/the_building_coder_samples/releases/tag/2018.0.135.2) and
 the extensive collection of filtered element examples in 
-the [module CmdCollectorPerformance.cs](https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/BuildingCoder/CmdCollectorPerformance.cs):
+the [module CmdCollectorPerformance.cs](https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/CmdCollectorPerformance.cs):
 
 <pre class="code">
   <span style="color:gray;">///</span><span style="color:green;">&nbsp;</span><span style="color:gray;">&lt;</span><span style="color:gray;">summary</span><span style="color:gray;">&gt;</span>

--- a/a/1624_brepbuilder.html
+++ b/a/1624_brepbuilder.html
@@ -335,7 +335,7 @@ and <a href="http://www.revitapidocs.com/2018.1/c4713a48-712b-e293-6745-a266af97
 <p>I added it 
 to <a href="https://github.com/jeremytammik/the_building_coder_samples">The Building Coder Samples</a> 
 <a href="https://github.com/jeremytammik/the_building_coder_samples/releases/tag/2018.0.136.0">release 2018.0.136.0</a> in
-the new <a href="https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/BuildingCoder/CmdBrepBuilder.cs">module CmdBrepBuilder.cs</a>.</p>
+the new <a href="https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/CmdBrepBuilder.cs">module CmdBrepBuilder.cs</a>.</p>
     </article>
     <div class="nav">
         <a href="index.html">← Back to Index</a>

--- a/a/1624_brepbuilder.md
+++ b/a/1624_brepbuilder.md
@@ -325,4 +325,4 @@ Many thanks to my colleagues Ryuji Ogasawara, Angel Velez, Boris Shafiro and Joh
 I added it 
 to [The Building Coder Samples](https://github.com/jeremytammik/the_building_coder_samples) 
 [release 2018.0.136.0](https://github.com/jeremytammik/the_building_coder_samples/releases/tag/2018.0.136.0) in
-the new [module CmdBrepBuilder.cs](https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/BuildingCoder/CmdBrepBuilder.cs).
+the new [module CmdBrepBuilder.cs](https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/CmdBrepBuilder.cs).

--- a/a/1629_change_text_colour.html
+++ b/a/1629_change_text_colour.html
@@ -155,7 +155,7 @@ on <a href="https://forums.autodesk.com/t5/revit-api-forum/how-to-change-text-co
 
 <p>Many thanks to Rudi and Richard for the helpful solutions!</p>
 <p>I added Rudi's utility function
-to <a href="https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/BuildingCoder/Util.cs#L455-L488">The Building Coder samples Util.cs module</a> like
+to <a href="https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/Util.cs#L455-L488">The Building Coder samples Util.cs module</a> like
 this:</p>
 <pre class="code">
 &nbsp;&nbsp;<span style="color:blue;">#region</span>&nbsp;Colour&nbsp;Conversion
@@ -185,7 +185,7 @@ this:</p>
 </pre>
 
 <p>To test it, I added an additional transaction step
-to <a href="https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/BuildingCoder/CmdNewTextNote.cs#L196-L216">CmdNewTextNote</a>:</p>
+to <a href="https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/CmdNewTextNote.cs#L196-L216">CmdNewTextNote</a>:</p>
 <pre class="code">
 <span style="color:blue;">using</span>(&nbsp;<span style="color:#2b91af;">Transaction</span>&nbsp;t&nbsp;=&nbsp;<span style="color:blue;">new</span>&nbsp;<span style="color:#2b91af;">Transaction</span>(&nbsp;doc&nbsp;)&nbsp;)
 {

--- a/a/1629_change_text_colour.md
+++ b/a/1629_change_text_colour.md
@@ -141,7 +141,7 @@ Richard [@RPTHOMAS108](https://forums.autodesk.com/t5/user/viewprofilepage/user-
 Many thanks to Rudi and Richard for the helpful solutions!
 
 I added Rudi's utility function
-to [The Building Coder samples Util.cs module](https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/BuildingCoder/Util.cs#L455-L488) like
+to [The Building Coder samples Util.cs module](https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/Util.cs#L455-L488) like
 this:
 
 <pre class="code">
@@ -171,7 +171,7 @@ this:
 </pre>
 
 To test it, I added an additional transaction step
-to [CmdNewTextNote](https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/BuildingCoder/CmdNewTextNote.cs#L196-L216):
+to [CmdNewTextNote](https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/CmdNewTextNote.cs#L196-L216):
 
 <pre class="code">
 <span style="color:blue;">using</span>(&nbsp;<span style="color:#2b91af;">Transaction</span>&nbsp;t&nbsp;=&nbsp;<span style="color:blue;">new</span>&nbsp;<span style="color:#2b91af;">Transaction</span>(&nbsp;doc&nbsp;)&nbsp;)

--- a/a/1632_filter_intersect.html
+++ b/a/1632_filter_intersect.html
@@ -243,7 +243,7 @@ the <a href="1382_filter_shortcuts.html#3">important difference between quick an
 </pre>
 
 <p>I implemented a new external
-command <a href="https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/BuildingCoder/CmdIntersectJunctionBox.cs">CmdIntersectJunctionBox</a>
+command <a href="https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/CmdIntersectJunctionBox.cs">CmdIntersectJunctionBox</a>
 in <a href="https://github.com/jeremytammik/the_building_coder_samples">The Building Coder samples</a> to try this out, in
 <a href="https://github.com/jeremytammik/the_building_coder_samples/releases/tag/2018.0.137.0">release 2018.0.137.0</a>.</p>
 <p>Waiting for a suitable sample model to test this on...</p>

--- a/a/1632_filter_intersect.md
+++ b/a/1632_filter_intersect.md
@@ -253,7 +253,7 @@ You may want to try them out yourself:
 </pre>
 
 I implemented a new external
-command [CmdIntersectJunctionBox](https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/BuildingCoder/CmdIntersectJunctionBox.cs)
+command [CmdIntersectJunctionBox](https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/CmdIntersectJunctionBox.cs)
 in [The Building Coder samples](https://github.com/jeremytammik/the_building_coder_samples) to try this out, in
 [release 2018.0.137.0](https://github.com/jeremytammik/the_building_coder_samples/releases/tag/2018.0.137.0).
 

--- a/a/1633_show_elements.html
+++ b/a/1633_show_elements.html
@@ -95,7 +95,7 @@ on <a href="0488_mirror_in_new_family.htm">mirroring in a new family and changin
 <p>As you can see on reading the final solution carefully, you can use the <code>ShowElements</code> method to change the active view and even switch it between the family and project documents. The official Revit 2011 API does not provide any method to switch the active view, but using <code>ShowElements</code> can be used to create a workaround for that."</p>
 </blockquote>
 <p>I implemented a new external
-command <a href="https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/BuildingCoder/CmdSwitchDoc.cs">CmdSwitchDoc</a>
+command <a href="https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/CmdSwitchDoc.cs">CmdSwitchDoc</a>
 in <a href="https://github.com/jeremytammik/the_building_coder_samples">The Building Coder samples</a> to try this out, in
 <a href="https://github.com/jeremytammik/the_building_coder_samples/releases/tag/2018.0.138.1">release 2018.0.138.1</a>.</p>
 <p>It demonstrates two uses of the <code>ShowElements</code> method:</p>

--- a/a/1633_show_elements.md
+++ b/a/1633_show_elements.md
@@ -83,7 +83,7 @@ on [mirroring in a new family and changing active view](0488_mirror_in_new_famil
 > As you can see on reading the final solution carefully, you can use the `ShowElements` method to change the active view and even switch it between the family and project documents. The official Revit 2011 API does not provide any method to switch the active view, but using `ShowElements` can be used to create a workaround for that."
 
 I implemented a new external
-command [CmdSwitchDoc](https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/BuildingCoder/CmdSwitchDoc.cs)
+command [CmdSwitchDoc](https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/CmdSwitchDoc.cs)
 in [The Building Coder samples](https://github.com/jeremytammik/the_building_coder_samples) to try this out, in
 [release 2018.0.138.1](https://github.com/jeremytammik/the_building_coder_samples/releases/tag/2018.0.138.1).
 

--- a/a/1636_connector_neighbour.html
+++ b/a/1636_connector_neighbour.html
@@ -46,7 +46,7 @@
 - connector neighbours
   https://forums.autodesk.com/t5/revit-api-forum/connector-neighbours/m-p/7816952
   https://github.com/geoffoverfield/RevitAPI_SystemSearch
-  https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/BuildingCoder/MepSystemSearch.cs
+  https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/MepSystemSearch.cs
 
 - connect into
   https://forums.autodesk.com/t5/revit-api-forum/connect-into/m-p/7834417
@@ -139,7 +139,7 @@ brought up a number of aspects of and solutions for traversing an MEP system and
 quick <a href="https://github.com/geoffoverfield/RevitAPI_SystemSearch">Revit API SystemSearch repo</a> for you to check it out.</p>
 <p>It's a pretty basic bit of source that I threw together real quick, but the general idea is there.  You'll definitely need to tweak it to meet your needs, but I hope it helps:</p>
 <p>It is now also included in <a href="https://github.com/jeremytammik/the_building_coder_samples">The Building Coder samples</a>,
-in <a href="https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/BuildingCoder/MepSystemSearch.cs">the module MepSystemSearch.cs</a>.</p>
+in <a href="https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/MepSystemSearch.cs">the module MepSystemSearch.cs</a>.</p>
 <p>You also need to be aware of the Revit SDK TraverseSystem sample. It determines the correct order of the individual system elements in the direction of the flow and stores the entire directed graph in XML.</p>
 <p>Here are some discussions of it:</p>
 <ul>

--- a/a/1636_connector_neighbour.md
+++ b/a/1636_connector_neighbour.md
@@ -15,7 +15,7 @@
 - connector neighbours
   https://forums.autodesk.com/t5/revit-api-forum/connector-neighbours/m-p/7816952
   https://github.com/geoffoverfield/RevitAPI_SystemSearch
-  https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/BuildingCoder/MepSystemSearch.cs
+  https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/MepSystemSearch.cs
 
 - connect into
   https://forums.autodesk.com/t5/revit-api-forum/connect-into/m-p/7834417
@@ -121,7 +121,7 @@ quick [Revit API SystemSearch repo](https://github.com/geoffoverfield/RevitAPI_S
 It's a pretty basic bit of source that I threw together real quick, but the general idea is there.  You'll definitely need to tweak it to meet your needs, but I hope it helps:
 
 It is now also included in [The Building Coder samples](https://github.com/jeremytammik/the_building_coder_samples),
-in [the module MepSystemSearch.cs](https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/BuildingCoder/MepSystemSearch.cs).
+in [the module MepSystemSearch.cs](https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/MepSystemSearch.cs).
 
 You also need to be aware of the Revit SDK TraverseSystem sample. It determines the correct order of the individual system elements in the direction of the flow and stores the entire directed graph in XML.
 

--- a/a/1640_part_atom_direct.html
+++ b/a/1640_part_atom_direct.html
@@ -172,7 +172,7 @@ one of the other approaches discussed there.</p>
 </pre>
 
 <p>I added Håvard's method to the existing external
-command <a href="https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/BuildingCoder/CmdPartAtom.cs">CmdPartAtom</a>
+command <a href="https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/CmdPartAtom.cs">CmdPartAtom</a>
 in <a href="https://github.com/jeremytammik/the_building_coder_samples">The Building Coder samples</a> to try this out, in
 <a href="httpshttps://github.com/jeremytammik/the_building_coder_samples/releases/tag/2018.0.138.4">release 2018.0.138.4</a>, and cleaned up the existing code calling the built-in Revit API method <code>ExtractPartAtomFromFamilyFile</code> at the same time.</p>
 <h4><a name="5"></a>Windows Explorer BasicFileInfo Right Click Utility</h4>

--- a/a/1640_part_atom_direct.md
+++ b/a/1640_part_atom_direct.md
@@ -180,7 +180,7 @@ Method here:
 </pre>
 
 I added Håvard's method to the existing external
-command [CmdPartAtom](https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/BuildingCoder/CmdPartAtom.cs)
+command [CmdPartAtom](https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/CmdPartAtom.cs)
 in [The Building Coder samples](https://github.com/jeremytammik/the_building_coder_samples) to try this out, in
 [release 2018.0.138.4](httpshttps://github.com/jeremytammik/the_building_coder_samples/releases/tag/2018.0.138.4), and cleaned up the existing code calling the built-in Revit API method `ExtractPartAtomFromFamilyFile` at the same time.
 

--- a/a/1652_revit_wcf_service.html
+++ b/a/1652_revit_wcf_service.html
@@ -325,7 +325,7 @@ provide a good starting point for you.</p>
 <p>It uses the built-in wall function parameter <code>FUNCTION_PARAM</code> to filter for exterior walls.</p>
 <p>I updated the code presented there and added it
 to <a href="https://github.com/jeremytammik/the_building_coder_samples">The Building Coder samples</a> for you,
-in the <a href="https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/BuildingCoder/CmdCollectorPerformance.cs#L293-L323">CmdCollectorPerformance.cs module lines L293-L323</a>.</p>
+in the <a href="https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/CmdCollectorPerformance.cs#L293-L323">CmdCollectorPerformance.cs module lines L293-L323</a>.</p>
 <p>First, we implement a predicate method <code>IsExterior</code> that checks this parameter value to determine whether a wall type is exterior or not:</p>
 <pre class="code">
   <span style="color:gray;">///</span><span style="color:green;">&nbsp;</span><span style="color:gray;">&lt;</span><span style="color:gray;">summary</span><span style="color:gray;">&gt;</span>

--- a/a/1652_revit_wcf_service.md
+++ b/a/1652_revit_wcf_service.md
@@ -352,7 +352,7 @@ It uses the built-in wall function parameter `FUNCTION_PARAM` to filter for exte
 
 I updated the code presented there and added it
 to [The Building Coder samples](https://github.com/jeremytammik/the_building_coder_samples) for you,
-in the [CmdCollectorPerformance.cs module lines L293-L323](https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/BuildingCoder/CmdCollectorPerformance.cs#L293-L323).
+in the [CmdCollectorPerformance.cs module lines L293-L323](https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/CmdCollectorPerformance.cs#L293-L323).
 
 First, we implement a predicate method `IsExterior` that checks this parameter value to determine whether a wall type is exterior or not:
 

--- a/a/1653_dwg_layer_visible.html
+++ b/a/1653_dwg_layer_visible.html
@@ -239,7 +239,7 @@ the <a href="zip/dwg_visible_geo.dwg">linked CAD file, <code>dwg_visible_geo.dwg
 <a href="https://github.com/jeremytammik/the_building_coder_samples/releases/tag/2019.0.139.2">release 2019.0.139.2</a>
 in
 order to format and preserve it for posterity in
-the <a href="https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/BuildingCoder/CmdProcessVisibleDwg.cs">module CmdProcessVisibleDwg.cs</a>.</p>
+the <a href="https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/CmdProcessVisibleDwg.cs">module CmdProcessVisibleDwg.cs</a>.</p>
 <h4><a name="3"></a>Import Image Using Foreground Option</h4>
 <p>Another import question, this time on images:</p>
 <p><strong>Question:</strong> When I insert a raster image into Revit, by default, it is displayed as 'background'.</p>

--- a/a/1653_dwg_layer_visible.md
+++ b/a/1653_dwg_layer_visible.md
@@ -229,7 +229,7 @@ I copied the macro code to
 [release 2019.0.139.2](https://github.com/jeremytammik/the_building_coder_samples/releases/tag/2019.0.139.2)
 in
 order to format and preserve it for posterity in
-the [module CmdProcessVisibleDwg.cs](https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/BuildingCoder/CmdProcessVisibleDwg.cs).
+the [module CmdProcessVisibleDwg.cs](https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/CmdProcessVisibleDwg.cs).
 
 
 ####<a name="3"></a>Import Image Using Foreground Option

--- a/a/1654_get_all_param_val.html
+++ b/a/1654_get_all_param_val.html
@@ -498,7 +498,7 @@ window (17 elements):
 
 <h4><a name="11"></a>Download</h4>
 <p>I added this code to the
-new <a href="https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/BuildingCoder/CmdParamValuesForCats.cs">module CmdParamValuesForCats.cs</a>
+new <a href="https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/CmdParamValuesForCats.cs">module CmdParamValuesForCats.cs</a>
 in <a href="https://github.com/jeremytammik/the_building_coder_samples">The Building Coder samples</a>
 <a href="https://github.com/jeremytammik/the_building_coder_samples/releases/tag/2019.0.140.0">release 2019.0.140.0</a>.</p>
 <p>I hope you find it useful.</p>

--- a/a/1654_get_all_param_val.md
+++ b/a/1654_get_all_param_val.md
@@ -526,7 +526,7 @@ window (17 elements):
 ####<a name="11"></a>Download
 
 I added this code to the
-new [module CmdParamValuesForCats.cs](https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/BuildingCoder/CmdParamValuesForCats.cs)
+new [module CmdParamValuesForCats.cs](https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/CmdParamValuesForCats.cs)
 in [The Building Coder samples](https://github.com/jeremytammik/the_building_coder_samples)
 [release 2019.0.140.0](https://github.com/jeremytammik/the_building_coder_samples/releases/tag/2019.0.140.0).
 

--- a/a/1656_exterior_walls.html
+++ b/a/1656_exterior_walls.html
@@ -152,7 +152,7 @@ the <span class="unavailable-link">'temporary transaction trick'</span>.</li>
 <p>One approach to achieve that might be to query each wall for its geometry or location curve, extract all their vertices, and construct a bounding box from them.</p>
 <p>However, querying a Revit element for its bounding box is much faster and more efficient than accessing and analysing its geometry or location curve.</p>
 <p>Moreover, <a href="https://github.com/jeremytammik/the_building_coder_samples">The Building Coder samples</a>
-<a href="https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/BuildingCoder/Util.cs"><code>Util</code> class</a> already
+<a href="https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/Util.cs"><code>Util</code> class</a> already
 implements a bounding box extension method <code>ExpandToContain</code> that we can use here, which expands a given bounding box to encompass another one:</p>
 <pre class="code">
 <span style="color:blue;">public</span>&nbsp;<span style="color:blue;">static</span>&nbsp;<span style="color:blue;">class</span>&nbsp;<span style="color:#2b91af;">JtBoundingBoxXyzExtensionMethods</span>

--- a/a/1656_exterior_walls.md
+++ b/a/1656_exterior_walls.md
@@ -173,7 +173,7 @@ One approach to achieve that might be to query each wall for its geometry or loc
 However, querying a Revit element for its bounding box is much faster and more efficient than accessing and analysing its geometry or location curve.
 
 Moreover, [The Building Coder samples](https://github.com/jeremytammik/the_building_coder_samples)
-[`Util` class](https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/BuildingCoder/Util.cs) already
+[`Util` class](https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/Util.cs) already
 implements a bounding box extension method `ExpandToContain` that we can use here, which expands a given bounding box to encompass another one:
 
 <pre class="code">

--- a/a/1672_cmdwallprofile_2019.html
+++ b/a/1672_cmdwallprofile_2019.html
@@ -87,7 +87,7 @@ Here are some other noteworthy items to keep company with my debugging report
 his <a href="http://forums.autodesk.com/t5/revit-api-forum/bd-p/160">Revit API discussion forum</a> thread 
 on the <a href="https://forums.autodesk.com/t5/revit-api-forum/get-wall-profile-error-cmdwallprofile-cs/m-p/8179152">get wall profile error</a>:</p>
 <p><strong>Question:</strong> I got an error testing
-the <a href="https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/BuildingCoder/CmdWallProfile.cs">CmdWallProfile external command</a>:</p>
+the <a href="https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/CmdWallProfile.cs">CmdWallProfile external command</a>:</p>
 <p><center>
 <img src="img/exception_in_getWallFace.jpg" alt="Exception in getWallFace" width="685"/>
 </center></p>

--- a/a/1672_cmdwallprofile_2019.md
+++ b/a/1672_cmdwallprofile_2019.md
@@ -65,7 +65,7 @@ on the [get wall profile error](https://forums.autodesk.com/t5/revit-api-forum/g
 
 
 **Question:** I got an error testing
-the [CmdWallProfile external command](https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/BuildingCoder/CmdWallProfile.cs):
+the [CmdWallProfile external command](https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/CmdWallProfile.cs):
 
 <center>
 <img src="img/exception_in_getWallFace.jpg" alt="Exception in getWallFace" width="685"/>

--- a/a/1679_delete_unused_ref_plane.html
+++ b/a/1679_delete_unused_ref_plane.html
@@ -205,7 +205,7 @@ when the <code>Delete</code> method overload taking an <code>Element</code> argu
 <p>Austin shared his version of the broken command, plus his new working solution.</p>
 <p>I added them both 
 to <a href="https://github.com/jeremytammik/the_building_coder_samples">The Building Coder Samples</a>
-<a href="https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/BuildingCoder/CmdDeleteUnusedRefPlanes.cs">module <code>CmdDeleteUnusedRefPlanes.cs</code></a>.</p>
+<a href="https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/CmdDeleteUnusedRefPlanes.cs">module <code>CmdDeleteUnusedRefPlanes.cs</code></a>.</p>
 <p>Yet again, I discovered a couple of optimisation possibilities that I very frequently keep pointing out and also added to Austin's code:</p>
 <ul>
 <li>Iterate directly over the filtered element collectors instead of converting it to a list, which wastes time and space for no benefit whatsoever.</li>

--- a/a/1679_delete_unused_ref_plane.md
+++ b/a/1679_delete_unused_ref_plane.md
@@ -206,7 +206,7 @@ Austin shared his version of the broken command, plus his new working solution.
 
 I added them both 
 to [The Building Coder Samples](https://github.com/jeremytammik/the_building_coder_samples)
-[module `CmdDeleteUnusedRefPlanes.cs`](https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/BuildingCoder/CmdDeleteUnusedRefPlanes.cs).
+[module `CmdDeleteUnusedRefPlanes.cs`](https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/CmdDeleteUnusedRefPlanes.cs).
 
 Yet again, I discovered a couple of optimisation possibilities that I very frequently keep pointing out and also added to Austin's code:
 

--- a/a/1680_refplane_in_family.html
+++ b/a/1680_refplane_in_family.html
@@ -145,7 +145,7 @@ to Alexander <a href="https://forums.autodesk.com/t5/user/viewprofilepage/user-i
 <p>By the way, I added this method 
 to <a href="https://github.com/jeremytammik/the_building_coder_samples">The Building Coder samples</a>,
 which heretofore lacked any example at all of using the relatively new family instance <code>GetReferences</code> method, in
-the <a href="https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/BuildingCoder/CmdDimensionInstanceOrigin.cs">module <code>CmdDimensionInstanceOrigin.cs</code></a>.</p>
+the <a href="https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/CmdDimensionInstanceOrigin.cs">module <code>CmdDimensionInstanceOrigin.cs</code></a>.</p>
 <h4><a name="4"></a> Accessing the Revit Ribbon Icons</h4>
 <p>Fair59 and Matt Taylor also recently provided another useful forum answer, in the two threads 
 on <a href="https://forums.autodesk.com/t5/revit-api-forum/revit-ribbon-icons-pictograms/m-p/8126270">Revit ribbon icons and pictograms</a>

--- a/a/1680_refplane_in_family.md
+++ b/a/1680_refplane_in_family.md
@@ -132,7 +132,7 @@ to Alexander [@aignatovich](https://forums.autodesk.com/t5/user/viewprofilepage/
 By the way, I added this method 
 to [The Building Coder samples](https://github.com/jeremytammik/the_building_coder_samples),
 which heretofore lacked any example at all of using the relatively new family instance `GetReferences` method, in
-the [module `CmdDimensionInstanceOrigin.cs`](https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/BuildingCoder/CmdDimensionInstanceOrigin.cs).
+the [module `CmdDimensionInstanceOrigin.cs`](https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/CmdDimensionInstanceOrigin.cs).
 
 
 ####<a name="4"></a> Accessing the Revit Ribbon Icons

--- a/a/1692_family_tamper_protect.html
+++ b/a/1692_family_tamper_protect.html
@@ -154,7 +154,7 @@ a <a href="https://en.wikipedia.org/wiki/Canonical_form">canonical form</a>.</p>
 </ul>
 <p>Most of these are implemented
 in <a href="https://github.com/jeremytammik/the_building_coder_samples">The Building Coder samples</a>
-<a href="https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/BuildingCoder/Util.cs">Util module</a>.</p>
+<a href="https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/Util.cs">Util module</a>.</p>
 <p>I'll leave it up to your imagination to improve these and define canonical keys for more complex data as required.</p>
 <p>Migliori saluti a Stefano!</p>
     </article>

--- a/a/1692_family_tamper_protect.md
+++ b/a/1692_family_tamper_protect.md
@@ -150,7 +150,7 @@ Here are some simplistic examples of defining canonical forms for real numbers, 
 
 Most of these are implemented
 in [The Building Coder samples](https://github.com/jeremytammik/the_building_coder_samples)
-[Util module](https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/BuildingCoder/Util.cs).
+[Util module](https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/Util.cs).
 
 
 I'll leave it up to your imagination to improve these and define canonical keys for more complex data as required.

--- a/a/1707_filter_intersect.html
+++ b/a/1707_filter_intersect.html
@@ -130,7 +130,7 @@ deals with <a href="https://forums.autodesk.com/t5/revit-api-forum/get-all-assoc
 the <span class="unavailable-link">Revit API getting started material</span> and
 also demonstrated in <a href="https://github.com/jeremytammik/the_building_coder_samples">The Building Coder samples</a>.</p>
 <p>For instance, in the latter, you can check out
-the <a href="https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/BuildingCoder/Util.cs#L1227-L1365">various element selection utility methods</a> and
+the <a href="https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/Util.cs#L1227-L1365">various element selection utility methods</a> and
 examine how they are used in the sample commands.</p>
 <p>Once you have found a usage pattern that you like in some sample command, search for the description of it
 in <span class="unavailable-link">The Building Coder blog</span>.</p>
@@ -141,7 +141,7 @@ in <span class="unavailable-link">The Building Coder blog</span>.</p>
 <li><a href="1639_linked_inters_filt.html">Using intersection filter with linked file</a></li>
 </ul>
 <p><a href="https://github.com/jeremytammik/the_building_coder_samples">The Building Coder samples</a>
-includes some examples of using a solid intersection filter, e.g., the <a href="https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/BuildingCoder/CmdCollectorPerformance.cs#L1294-L1430"><code>GetInstancesIntersectingElement</code> method</a> showing
+includes some examples of using a solid intersection filter, e.g., the <a href="https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/CmdCollectorPerformance.cs#L1294-L1430"><code>GetInstancesIntersectingElement</code> method</a> showing
 how to retrieve family instances intersecting a given BIM element:</p>
 <pre class="code">
 &nbsp;&nbsp;&nbsp;<span style="color:gray;">///</span><span style="color:green;">&nbsp;</span><span style="color:gray;">&lt;</span><span style="color:gray;">summary</span><span style="color:gray;">&gt;</span>

--- a/a/1707_filter_intersect.md
+++ b/a/1707_filter_intersect.md
@@ -121,7 +121,7 @@ the Revit API getting started material *(link unavailable)* and
 also demonstrated in [The Building Coder samples](https://github.com/jeremytammik/the_building_coder_samples).
 
 For instance, in the latter, you can check out
-the [various element selection utility methods](https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/BuildingCoder/Util.cs#L1227-L1365) and
+the [various element selection utility methods](https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/Util.cs#L1227-L1365) and
 examine how they are used in the sample commands.
 
 Once you have found a usage pattern that you like in some sample command, search for the description of it
@@ -135,7 +135,7 @@ Set it up to retrieve rebar elements only, and add a filter for the column solid
 - [Using intersection filter with linked file](1639_linked_inters_filt.html)
 
 [The Building Coder samples](https://github.com/jeremytammik/the_building_coder_samples)
-includes some examples of using a solid intersection filter, e.g., the [`GetInstancesIntersectingElement` method](https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/BuildingCoder/CmdCollectorPerformance.cs#L1294-L1430) showing
+includes some examples of using a solid intersection filter, e.g., the [`GetInstancesIntersectingElement` method](https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/CmdCollectorPerformance.cs#L1294-L1430) showing
 how to retrieve family instances intersecting a given BIM element:
 
 <pre class="code">

--- a/a/1713_room_boundary_wpf.html
+++ b/a/1713_room_boundary_wpf.html
@@ -70,7 +70,7 @@ Ali Asad presented a new Visual Studio WPF MVVM Revit add-in template
 </center></p>
 <p>One simple way to obtain them via the Revit API is demonstrated
 by <a href="https://github.com/jeremytammik/the_building_coder_samples">The Building Coder samples</a> in
-the <a href="https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/BuildingCoder/CmdListAllRooms.cs">external command <code>CmdListAllRooms</code></a>.</p>
+the <a href="https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/CmdListAllRooms.cs">external command <code>CmdListAllRooms</code></a>.</p>
 <p>It was originally presented in 2011, and enhanced in some further discussions:</p>
 <ul>
 <li><a href="0682_accessing_room_data.htm">Accessing room data</a>.</li>

--- a/a/1713_room_boundary_wpf.md
+++ b/a/1713_room_boundary_wpf.md
@@ -46,7 +46,7 @@ A Forge BIM surface classification tool requires room boundaries to display them
 
 One simple way to obtain them via the Revit API is demonstrated
 by [The Building Coder samples](https://github.com/jeremytammik/the_building_coder_samples) in
-the [external command `CmdListAllRooms`](https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/BuildingCoder/CmdListAllRooms.cs).
+the [external command `CmdListAllRooms`](https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/CmdListAllRooms.cs).
 
 It was originally presented in 2011, and enhanced in some further discussions:
 

--- a/a/1724_multi_loop_newsweep.html
+++ b/a/1724_multi_loop_newsweep.html
@@ -88,7 +88,7 @@ on <a href="https://forums.autodesk.com/t5/revit-api-forum/how-to-create-a-sweep
 <p><strong>Answer:</strong> Every loop needs to be a separate <code>CurveArray</code>!</p>
 <p>I added Frank's correction to the test code provided and integrated it
 into <a href="https://github.com/jeremytammik/the_building_coder_samples">The Building Coder samples</a> 
-module <a href="https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/BuildingCoder/CmdNewSweptBlend.cs">CmdNewSweptBlend.cs</a>:</p>
+module <a href="https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/CmdNewSweptBlend.cs">CmdNewSweptBlend.cs</a>:</p>
 <pre class="code">
 &nbsp;&nbsp;<span style="color:blue;">public</span>&nbsp;<span style="color:#2b91af;">Sweep</span>&nbsp;CreateSweepWithMultipleLoops(
 &nbsp;&nbsp;&nbsp;&nbsp;<span style="color:#2b91af;">Document</span>&nbsp;doc&nbsp;)

--- a/a/1724_multi_loop_newsweep.md
+++ b/a/1724_multi_loop_newsweep.md
@@ -72,7 +72,7 @@ I tried orienting the two inner loops both clockwise and counterclockwise, but n
 
 I added Frank's correction to the test code provided and integrated it
 into [The Building Coder samples](https://github.com/jeremytammik/the_building_coder_samples) 
-module [CmdNewSweptBlend.cs](https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/BuildingCoder/CmdNewSweptBlend.cs):
+module [CmdNewSweptBlend.cs](https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/CmdNewSweptBlend.cs):
 
 <pre class="code">
 &nbsp;&nbsp;<span style="color:blue;">public</span>&nbsp;<span style="color:#2b91af;">Sweep</span>&nbsp;CreateSweepWithMultipleLoops(

--- a/a/1736_faster_filtering.html
+++ b/a/1736_faster_filtering.html
@@ -122,7 +122,7 @@ of <a href="1382_filter_shortcuts.html">quick, slow and LINQ element filtering</
 a <a href="1659_param_filter.html#3">parameter filter to compare the family name</a>.</p>
 <p>That discussion does not show how to actually implement the parameter filter.</p>
 <p>I therefore cleaned up The Building Coder sample code
-demonstrating <a href="https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/BuildingCoder/CmdCollectorPerformance.cs#L1203-L1255">retrieving named family symbols using either LINQ or a parameter filter</a> for
+demonstrating <a href="https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/CmdCollectorPerformance.cs#L1203-L1255">retrieving named family symbols using either LINQ or a parameter filter</a> for
 you to illustrate how to do that:</p>
 <pre class="code">
   <span style="color:blue;">#region</span>&nbsp;Retrieve&nbsp;named&nbsp;family&nbsp;symbols&nbsp;using&nbsp;either&nbsp;LINQ&nbsp;or&nbsp;a&nbsp;parameter&nbsp;filter

--- a/a/1736_faster_filtering.md
+++ b/a/1736_faster_filtering.md
@@ -108,7 +108,7 @@ a [parameter filter to compare the family name](1659_param_filter.html#3).
 That discussion does not show how to actually implement the parameter filter.
 
 I therefore cleaned up The Building Coder sample code
-demonstrating [retrieving named family symbols using either LINQ or a parameter filter](https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/BuildingCoder/CmdCollectorPerformance.cs#L1203-L1255) for
+demonstrating [retrieving named family symbols using either LINQ or a parameter filter](https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/CmdCollectorPerformance.cs#L1203-L1255) for
 you to illustrate how to do that:
 
 <pre class="code">

--- a/a/1737_ipc.html
+++ b/a/1737_ipc.html
@@ -180,7 +180,7 @@ Does anyone here have experience?</p>
 <img src="img/floor_set_level_1.png" alt="After running add-in" width="448">
 </center></p>
 <p>Saved for posterity in the method <code>SetFloorLevelAndOffset</code> in
-the <a href="https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/BuildingCoder/CmdEditFloor.cs">module CmdEditFloor.cs</a>
+the <a href="https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/CmdEditFloor.cs">module CmdEditFloor.cs</a>
 of <a href="https://github.com/jeremytammik/the_building_coder_samples">The Building Coder samples</a>
 <a href="https://github.com/jeremytammik/the_building_coder_samples/releases/tag/2019.0.145.17">release 2019.0.145.17</a>, cf.
 the <a href="https://github.com/jeremytammik/the_building_coder_samples/compare/2019.0.145.16...2019.0.145.17">diff from the previous release</a>.</p>

--- a/a/1737_ipc.md
+++ b/a/1737_ipc.md
@@ -166,7 +166,7 @@ Model after running add-in:
 </center>
 
 Saved for posterity in the method `SetFloorLevelAndOffset` in
-the [module CmdEditFloor.cs](https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/BuildingCoder/CmdEditFloor.cs)
+the [module CmdEditFloor.cs](https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/CmdEditFloor.cs)
 of [The Building Coder samples](https://github.com/jeremytammik/the_building_coder_samples)
 [release 2019.0.145.17](https://github.com/jeremytammik/the_building_coder_samples/releases/tag/2019.0.145.17), cf.
 the [diff from the previous release](https://github.com/jeremytammik/the_building_coder_samples/compare/2019.0.145.16...2019.0.145.17).

--- a/a/1756_bim360_links.html
+++ b/a/1756_bim360_links.html
@@ -200,7 +200,7 @@ This is an old sample.</li>
 <p>I added this sample code
 to <a href="https://github.com/jeremytammik/the_building_coder_samples">The Building Coder samples</a>
 as a new external
-command <a href="https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/BuildingCoder/CmdBim360Links.cs">CmdBim360Links </a>
+command <a href="https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/CmdBim360Links.cs">CmdBim360Links </a>
 in <a href="https://github.com/jeremytammik/the_building_coder_samples/releases/tag/2020.0.146.0">release 2020.0.146.0</a></p>
 <h4><a name="3"></a> Retrieve RVT Preview Thumbnail Image with Python</h4>
 <p>Franco Tonutti researched and solved how to retrieve the RVT preview thumbnail image with Python

--- a/a/1756_bim360_links.md
+++ b/a/1756_bim360_links.md
@@ -184,7 +184,7 @@ Many thanks to Eason for this research and clear explanation!
 I added this sample code
 to [The Building Coder samples](https://github.com/jeremytammik/the_building_coder_samples)
 as a new external
-command [CmdBim360Links ](https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/BuildingCoder/CmdBim360Links.cs)
+command [CmdBim360Links ](https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/CmdBim360Links.cs)
 in [release 2020.0.146.0](https://github.com/jeremytammik/the_building_coder_samples/releases/tag/2020.0.146.0)
 
 

--- a/a/1764_rebar_curves_wizard_zip.html
+++ b/a/1764_rebar_curves_wizard_zip.html
@@ -131,7 +131,7 @@ an <a href="https://blogs.autodesk.com/revit/2019/07/21/revit-public-roadmap-jul
 the <a href="http://www.autodesk.com/RevitIdeas">Revit Idea Station</a>.</p>
 <h4><a name="3"></a> Rebar Curves</h4>
 <p>I recently implemented
-a new <a href="https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/BuildingCoder/CmdRebarCurves.cs">external command <code>CmdRebarCurves</code></a>
+a new <a href="https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/CmdRebarCurves.cs">external command <code>CmdRebarCurves</code></a>
 in <a href="https://github.com/jeremytammik/the_building_coder_samples">The Building Coder samples</a>.</p>
 <p>It was originally intended to be used to simplify and minimise models for Forge processing.</p>
 <p>However, it seems that may no longer be required, since
@@ -166,7 +166,7 @@ I tried using the following method:</p>
 <p>P.S. I found another way to achieve what I want by translating the first rebar curves along the direction of rebar set.</p>
 <p><strong>Answer:</strong> Congratulations on solving the problem as described in your post scriptum.</p>
 <p>Take a look at the
-new <a href="https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/BuildingCoder/CmdRebarCurves.cs">external command <code>CmdRebarCurves</code></a>
+new <a href="https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/CmdRebarCurves.cs">external command <code>CmdRebarCurves</code></a>
 in <a href="https://github.com/jeremytammik/the_building_coder_samples">The Building Coder samples</a>.</p>
 <p>It seems to be using the very same approach you describe.</p>
 <p>Manuel Solís López of <a href="https://www.sofistik.com">SOFiSTiK AG</a> explains:</p>

--- a/a/1764_rebar_curves_wizard_zip.md
+++ b/a/1764_rebar_curves_wizard_zip.md
@@ -110,7 +110,7 @@ the [Revit Idea Station](http://www.autodesk.com/RevitIdeas).
 ####<a name="3"></a> Rebar Curves
 
 I recently implemented
-a new [external command `CmdRebarCurves`](https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/BuildingCoder/CmdRebarCurves.cs)
+a new [external command `CmdRebarCurves`](https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/CmdRebarCurves.cs)
 in [The Building Coder samples](https://github.com/jeremytammik/the_building_coder_samples).
 
 It was originally intended to be used to simplify and minimise models for Forge processing.
@@ -154,7 +154,7 @@ P.S. I found another way to achieve what I want by translating the first rebar c
 **Answer:** Congratulations on solving the problem as described in your post scriptum.
 
 Take a look at the
-new [external command `CmdRebarCurves`](https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/BuildingCoder/CmdRebarCurves.cs)
+new [external command `CmdRebarCurves`](https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/CmdRebarCurves.cs)
 in [The Building Coder samples](https://github.com/jeremytammik/the_building_coder_samples).
 
 It seems to be using the very same approach you describe.

--- a/a/1766_khl_snoop.html
+++ b/a/1766_khl_snoop.html
@@ -211,7 +211,7 @@ to validate these assumptions of mine in your own specific model.</p>
 </pre>
 
 <p>For future reference, I also added this code to <a href="https://github.com/jeremytammik/the_building_coder_samples">The Building Coder samples</a> in
-the <a href="https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/BuildingCoder/CmdCollectorPerformance.cs#L1223-L1240">CmdCollectorPerformance.cs module</a></p>
+the <a href="https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/CmdCollectorPerformance.cs#L1223-L1240">CmdCollectorPerformance.cs module</a></p>
 <p>Finally, you can use the built-in Revit macro IDE (integrated development environment) to convert this code from C# to Python, if you like.</p>
 <h4><a name="5"></a> Vertex Handling</h4>
 <p>Another recent recurring question on vertex handling may also be of general interest:</p>

--- a/a/1766_khl_snoop.md
+++ b/a/1766_khl_snoop.md
@@ -206,7 +206,7 @@ If these assumptions are correct, the final solution might look something like t
 </pre>
 
 For future reference, I also added this code to [The Building Coder samples](https://github.com/jeremytammik/the_building_coder_samples) in
-the [CmdCollectorPerformance.cs module](https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/BuildingCoder/CmdCollectorPerformance.cs#L1223-L1240)
+the [CmdCollectorPerformance.cs module](https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/CmdCollectorPerformance.cs#L1223-L1240)
 
 Finally, you can use the built-in Revit macro IDE (integrated development environment) to convert this code from C# to Python, if you like.
 

--- a/a/1773_face_intersect_face.html
+++ b/a/1773_face_intersect_face.html
@@ -128,7 +128,7 @@ the <a href="https://www.revitapidocs.com/2020/91f650a2-bb95-650b-7c00-d431fa613
 <p><strong>Answer:</strong> Thank you for your report and reproducible case.</p>
 <p>I see the same behaviour in Revit 2019 as well.</p>
 <p>I added some code to The Building Coder samples
-in <a href="https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/BuildingCoder/CmdIntersectJunctionBox.cs#L27-L116">CmdIntersectJunctionBox.cs</a> to
+in <a href="https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/CmdIntersectJunctionBox.cs#L27-L116">CmdIntersectJunctionBox.cs</a> to
 test and report in more depth:</p>
 <pre class="code">
 <span style="color:gray;">///</span><span style="color:green;">&nbsp;</span><span style="color:gray;">&lt;</span><span style="color:gray;">summary</span><span style="color:gray;">&gt;</span>

--- a/a/1773_face_intersect_face.md
+++ b/a/1773_face_intersect_face.md
@@ -121,7 +121,7 @@ When I run the code below in a view with a single wall and single floor, each fa
 I see the same behaviour in Revit 2019 as well.
 
 I added some code to The Building Coder samples
-in [CmdIntersectJunctionBox.cs](https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/BuildingCoder/CmdIntersectJunctionBox.cs#L27-L116) to
+in [CmdIntersectJunctionBox.cs](https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/CmdIntersectJunctionBox.cs#L27-L116) to
 test and report in more depth:
 
 <pre class="code">

--- a/a/1792_dynamo_infrastructure.html
+++ b/a/1792_dynamo_infrastructure.html
@@ -183,7 +183,7 @@ once again showing the use of simple snooping to discover what is going on under
 I bring in one family instance based on the selected model line.
 I have an issue placing another family instance in the project based on a selected edge in the already placed family instance.
 It is placed in opposite orientation (it seems rotated).
-I used code for <code>GetInstanceEdgeFromSymbolRef</code> from <a href="https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/BuildingCoder/CmdDimensionInstanceOrigin.cs">The Building Coder samples CmdDimensionInstanceOrigin module</a> to select the reference edge for placing the second family instance.
+I used code for <code>GetInstanceEdgeFromSymbolRef</code> from <a href="https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/CmdDimensionInstanceOrigin.cs">The Building Coder samples CmdDimensionInstanceOrigin module</a> to select the reference edge for placing the second family instance.
 Points of the selected edge are correct as per code in above link.
 But the orientation of the selected geometry seems to be wrong. </p>
 <p>Placing manually using family instance edge is working fine.</p>

--- a/a/1792_dynamo_infrastructure.md
+++ b/a/1792_dynamo_infrastructure.md
@@ -180,7 +180,7 @@ once again showing the use of simple snooping to discover what is going on under
 I bring in one family instance based on the selected model line.
 I have an issue placing another family instance in the project based on a selected edge in the already placed family instance.
 It is placed in opposite orientation (it seems rotated).
-I used code for `GetInstanceEdgeFromSymbolRef` from [The Building Coder samples CmdDimensionInstanceOrigin module](https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/BuildingCoder/CmdDimensionInstanceOrigin.cs) to select the reference edge for placing the second family instance.
+I used code for `GetInstanceEdgeFromSymbolRef` from [The Building Coder samples CmdDimensionInstanceOrigin module](https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/CmdDimensionInstanceOrigin.cs) to select the reference edge for placing the second family instance.
 Points of the selected edge are correct as per code in above link.
 But the orientation of the selected geometry seems to be wrong. 
 

--- a/a/1802_electrical_load.html
+++ b/a/1802_electrical_load.html
@@ -68,7 +68,7 @@ the [Revit API discussion forum](http://forums.autodesk.com/t5/revit-api-forum/b
 <p>I am not completely successful, though, I'm afraid.</p>
 <p>Very kindly, Alexander <a href="https://forums.autodesk.com/t5/user/viewprofilepage/user-id/1257478">@aignatovich</a> <a href="https://github.com/CADBIMDeveloper">@CADBIMDeveloper</a> Ignatovich, aka Александр Игнатович,
 provided us all with a gift for the day in the form of a new external
-command <a href="https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/BuildingCoder/CmdElectricalLoad.cs">CmdElectricalLoad</a> that he submitted 
+command <a href="https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/CmdElectricalLoad.cs">CmdElectricalLoad</a> that he submitted 
 to <a href="https://github.com/jeremytammik/the_building_coder_samples">The Building Coder samples</a>
 in <a href="https://github.com/jeremytammik/the_building_coder_samples/pull/12">pull request #12</a>, saying:</p>
 <blockquote>

--- a/a/1802_electrical_load.md
+++ b/a/1802_electrical_load.md
@@ -46,7 +46,7 @@ I am not completely successful, though, I'm afraid.
 
 Very kindly, Alexander [@aignatovich](https://forums.autodesk.com/t5/user/viewprofilepage/user-id/1257478) [@CADBIMDeveloper](https://github.com/CADBIMDeveloper) Ignatovich, aka Александр Игнатович,
 provided us all with a gift for the day in the form of a new external
-command [CmdElectricalLoad](https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/BuildingCoder/CmdElectricalLoad.cs) that he submitted 
+command [CmdElectricalLoad](https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/CmdElectricalLoad.cs) that he submitted 
 to [The Building Coder samples](https://github.com/jeremytammik/the_building_coder_samples)
 in [pull request #12](https://github.com/jeremytammik/the_building_coder_samples/pull/12), saying:
 

--- a/a/1820_sheet_from_view.html
+++ b/a/1820_sheet_from_view.html
@@ -257,7 +257,7 @@ to <a href="0371_sheet_size.htm">determine sheet size</a> that
 should provide all you need.</p>
 <p>The code is included in
 <a href="https://github.com/jeremytammik/the_building_coder_samples">The Building Coder samples</a>
-<a href="https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/BuildingCoder/CmdSheetSize.cs">module CmdSheetSize.cs</a>.</p>
+<a href="https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/CmdSheetSize.cs">module CmdSheetSize.cs</a>.</p>
 <p>The title block instances are family instance elements.
 You can access the title block element using a filtered element collector, e.g.:</p>
 <pre class="code">

--- a/a/1820_sheet_from_view.md
+++ b/a/1820_sheet_from_view.md
@@ -260,7 +260,7 @@ should provide all you need.
 
 The code is included in
 [The Building Coder samples](https://github.com/jeremytammik/the_building_coder_samples)
-[module CmdSheetSize.cs](https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/BuildingCoder/CmdSheetSize.cs).
+[module CmdSheetSize.cs](https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/CmdSheetSize.cs).
 
 The title block instances are family instance elements.
 You can access the title block element using a filtered element collector, e.g.:

--- a/a/1849_change_elem_color.html
+++ b/a/1849_change_elem_color.html
@@ -144,7 +144,7 @@ change the colour of a selected element in the current view like this:</p>
 </pre>
 
 <p>This code now lives in the 
-new <a href="https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/BuildingCoder/CmdChangeElementColor.cs">sample command <code>CmdChangeElementColor</code></a>
+new <a href="https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/CmdChangeElementColor.cs">sample command <code>CmdChangeElementColor</code></a>
 in <a href="https://github.com/jeremytammik/the_building_coder_samples">The Building Coder samples</a>.</p>
 <h4><a name="3"></a> Assign new Material to an Element</h4>
 <p>A slightly trickier question is how to assign a new material:</p>

--- a/a/1849_change_elem_color.md
+++ b/a/1849_change_elem_color.md
@@ -120,7 +120,7 @@ change the colour of a selected element in the current view like this:
 </pre>
 
 This code now lives in the 
-new [sample command `CmdChangeElementColor`](https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/BuildingCoder/CmdChangeElementColor.cs)
+new [sample command `CmdChangeElementColor`](https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/CmdChangeElementColor.cs)
 in [The Building Coder samples](https://github.com/jeremytammik/the_building_coder_samples).
 
 ####<a name="3"></a> Assign new Material to an Element

--- a/a/1863_param_optimise_tbcfts.html
+++ b/a/1863_param_optimise_tbcfts.html
@@ -211,7 +211,7 @@ on <a href="https://forums.autodesk.com/t5/revit-api-forum/modify-shared-paramet
 <p>I added this code in the original and updated forms
 to <a href="https://github.com/jeremytammik/the_building_coder_samples">The Building Coder samples</a>.</p>
 <p>Here is the <a href="https://github.com/jeremytammik/the_building_coder_samples/commit/fea7381f51b660fc9b5660c2e64f548623b11d8b">diff between the two</a>.
-and the <a href="https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/BuildingCoder/CmdCreateSharedParams.cs#L547-L584">current implementation code</a>.</p>
+and the <a href="https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/CmdCreateSharedParams.cs#L547-L584">current implementation code</a>.</p>
 <p>Please equip your code with a little benchmark timer stopwatch and let us know whether this helps and how it affects the processing time required before and after making this modification.</p>
 <p><strong>Response:</strong> I applied the solution and the execution time improved.</p>
 <p>Here are some results before and after the modification, correlating the number of family instances with the execution time required in milliseconds before and after the enhancement:</p>

--- a/a/1863_param_optimise_tbcfts.md
+++ b/a/1863_param_optimise_tbcfts.md
@@ -203,7 +203,7 @@ I added this code in the original and updated forms
 to [The Building Coder samples](https://github.com/jeremytammik/the_building_coder_samples).
 
 Here is the [diff between the two](https://github.com/jeremytammik/the_building_coder_samples/commit/fea7381f51b660fc9b5660c2e64f548623b11d8b).
-and the [current implementation code](https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/BuildingCoder/CmdCreateSharedParams.cs#L547-L584).
+and the [current implementation code](https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/CmdCreateSharedParams.cs#L547-L584).
 
 Please equip your code with a little benchmark timer stopwatch and let us know whether this helps and how it affects the processing time required before and after making this modification.
 

--- a/a/1868_outline_performance.html
+++ b/a/1868_outline_performance.html
@@ -140,7 +140,7 @@ Is there are right way to achieve this with the Revit API?</p>
 <p>However, there may be many possibilities to optimise your code.
 The Building Coder provides various utility functions that may help.
 For instance, to <a href="1538_fam_bb_aec_hack.html#3">determine the bounding box of an entire family</a>.
-Many more in <a href="https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/BuildingCoder/Util.cs">The Building Coder samples <code>Util</code> module</a>.
+Many more in <a href="https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/Util.cs">The Building Coder samples <code>Util</code> module</a>.
 Search there for "bounding box".
 I am sure they can be further optimised as well for your case.
 For instance, you may be able to extract all the <code>X</code> coordinates from all the individual elements' bounding box <code>Max</code> values and use a generic <code>Max</code> function to determine their maximum in one single call instead of comparing them one by one.
@@ -457,7 +457,7 @@ When there is a line penetrating the plane, I guess there is an intersection poi
 the <a href="https://www.revitapidocs.com/2020/3513f5e2-a274-4f60-4d8f-78145930a9e3.htm"><code>Face</code> <code>Intersect</code> method taking a <code>Curve</code> argument</a>.</p>
 <p>I do not understand why you prefer to ask this question here instead of searching for these results yourself.</p>
 <p>It took me much longer to write them down than to find them.</p>
-<p>I even went ahead and implemented a <a href="https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/BuildingCoder/Util.cs#L638-L681">line-plane intersection method <code>LinePlaneIntersection</code></a> for
+<p>I even went ahead and implemented a <a href="https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/Util.cs#L638-L681">line-plane intersection method <code>LinePlaneIntersection</code></a> for
 you in The Building Coder samples.</p>
 <p>Here is the code:</p>
 <pre class="code">

--- a/a/1868_outline_performance.md
+++ b/a/1868_outline_performance.md
@@ -121,7 +121,7 @@ Is there are right way to achieve this with the Revit API?
 However, there may be many possibilities to optimise your code.
 The Building Coder provides various utility functions that may help.
 For instance, to [determine the bounding box of an entire family](1538_fam_bb_aec_hack.html#3).
-Many more in [The Building Coder samples `Util` module](https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/BuildingCoder/Util.cs).
+Many more in [The Building Coder samples `Util` module](https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/Util.cs).
 Search there for "bounding box".
 I am sure they can be further optimised as well for your case.
 For instance, you may be able to extract all the `X` coordinates from all the individual elements' bounding box `Max` values and use a generic `Max` function to determine their maximum in one single call instead of comparing them one by one.
@@ -461,7 +461,7 @@ I do not understand why you prefer to ask this question here instead of searchin
 
 It took me much longer to write them down than to find them.
 
-I even went ahead and implemented a [line-plane intersection method `LinePlaneIntersection`](https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/BuildingCoder/Util.cs#L638-L681) for
+I even went ahead and implemented a [line-plane intersection method `LinePlaneIntersection`](https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/Util.cs#L638-L681) for
 you in The Building Coder samples.
 
 Here is the code:

--- a/a/1871_elbow_centre.html
+++ b/a/1871_elbow_centre.html
@@ -214,7 +214,7 @@ I just found out that actually the elbow already has the centre point informatio
 <ul>
 <li><a href="https://www.revitapidocs.com/2020/28a9cf5e-9191-f9ce-74c8-622a681201f6.htm">Connector Origin</a></li>
 <li><a href="https://www.revitapidocs.com/2020/cb6d725d-654a-f6f3-fed0-96cc618a42f1.htm">CoordinateSystem property returning a Transform object</a></li>
-<li><a href="https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/BuildingCoder/CmdRectDuctCorners.cs#L240-L319">New <code>GetElbowConnectors</code> and <code>GetElbowCentre</code> methods in The Building Coder samples</a> </li>
+<li><a href="https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/CmdRectDuctCorners.cs#L240-L319">New <code>GetElbowConnectors</code> and <code>GetElbowCentre</code> methods in The Building Coder samples</a> </li>
 </ul>
 <pre class="code">
   <span style="color:gray;">///</span><span style="color:green;">&nbsp;</span><span style="color:gray;">&lt;</span><span style="color:gray;">summary</span><span style="color:gray;">&gt;</span>

--- a/a/1871_elbow_centre.md
+++ b/a/1871_elbow_centre.md
@@ -212,7 +212,7 @@ I implemented a geometrical solution for you based on the elbow connectors and t
 
 - [Connector Origin](https://www.revitapidocs.com/2020/28a9cf5e-9191-f9ce-74c8-622a681201f6.htm)
 - [CoordinateSystem property returning a Transform object](https://www.revitapidocs.com/2020/cb6d725d-654a-f6f3-fed0-96cc618a42f1.htm)
-- [New `GetElbowConnectors` and `GetElbowCentre` methods in The Building Coder samples](https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/BuildingCoder/CmdRectDuctCorners.cs#L240-L319) 
+- [New `GetElbowConnectors` and `GetElbowCentre` methods in The Building Coder samples](https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/CmdRectDuctCorners.cs#L240-L319) 
 
 <pre class="code">
   <span style="color:gray;">///</span><span style="color:green;">&nbsp;</span><span style="color:gray;">&lt;</span><span style="color:gray;">summary</span><span style="color:gray;">&gt;</span>

--- a/a/1908_forgetypeid.html
+++ b/a/1908_forgetypeid.html
@@ -191,7 +191,7 @@ of <a href="https://archi-lab.net/handling-the-revit-2022-unit-changes">handling
 <p>This was discussed and resolved in the StackOverflow question
 on <a href="https://stackoverflow.com/questions/63992151/autodesk-forge-is-returning-odd-measurement-data">Autodesk Forge returning odd measurement data</a></p>
 <p>I ended up implementing
-the <a href="https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/BuildingCoder/Util.cs#L1306-L1367">method <code>ListForgeTypeIds</code> in The Building Coder samples</a> to help resolve the issue.</p>
+the <a href="https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/Util.cs#L1306-L1367">method <code>ListForgeTypeIds</code> in The Building Coder samples</a> to help resolve the issue.</p>
 <p>I also shared this in the discussion 
 on <a href="https://forums.autodesk.com/t5/revit-api-forum/displayunittype-in-revit-2022/m-p/10320697">DisplayUnitType in Revit 2022</a>.</p>
 <h4><a name="5"></a> Unit Conversion Without Knowing</h4>

--- a/a/1908_forgetypeid.md
+++ b/a/1908_forgetypeid.md
@@ -179,7 +179,7 @@ This was discussed and resolved in the StackOverflow question
 on [Autodesk Forge returning odd measurement data](https://stackoverflow.com/questions/63992151/autodesk-forge-is-returning-odd-measurement-data)
 
 I ended up implementing
-the [method `ListForgeTypeIds` in The Building Coder samples](https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/BuildingCoder/Util.cs#L1306-L1367) to help resolve the issue.
+the [method `ListForgeTypeIds` in The Building Coder samples](https://github.com/jeremytammik/the_building_coder_samples/blob/master/BuildingCoder/Util.cs#L1306-L1367) to help resolve the issue.
 
 I also shared this in the discussion 
 on [DisplayUnitType in Revit 2022](https://forums.autodesk.com/t5/revit-api-forum/displayunittype-in-revit-2022/m-p/10320697).


### PR DESCRIPTION
A couple of links contained a duplicate `/BuildingCoder/BuildingCoder/` path  segment that should be `/BuildingCoder/`.

Replaced those and ran a check with curl to confirm and all links returned 200.